### PR TITLE
TLS ABC PEP draft

### DIFF
--- a/pep-0xxx.rst
+++ b/pep-0xxx.rst
@@ -630,9 +630,16 @@ has the following definition::
             attempts to read would raise either ``WantReadError`` or
             ``WantWriteError``.
 
+            Once EOF is reached, all further calls to this method return the
+            empty byte string ``b''``.
+
             Raise ``WantReadError`` or ``WantWriteError`` if there is
             insufficient data in either the input or output buffer and the
             operation would have caused data to be written or read.
+
+            May raise ``RaggedEOF`` if the connection has been closed without a
+            graceful TLS shutdown. Whether this is an exception that should be
+            ignored or not is up to the specific application.
 
             As at any time a re-negotiation is possible, a call to ``read()``
             can also cause write operations.
@@ -648,9 +655,16 @@ has the following definition::
             attempts to read would raise either ``WantReadError`` or
             ``WantWriteError``, or until the buffer is full.
 
+            Once EOF is reached, all further calls to this method return the
+            empty byte string ``b''``.
+
             Raises ``WantReadError`` or ``WantWriteError`` if there is
             insufficient data in either the input or output buffer and the
             operation would have caused data to be written or read.
+
+            May raise ``RaggedEOF`` if the connection has been closed without a
+            graceful TLS shutdown. Whether this is an exception that should be
+            ignored or not is up to the specific application.
 
             As at any time a re-negotiation is possible, a call to
             ``readinto()`` can also cause write operations.
@@ -937,7 +951,7 @@ implementation.
 Errors
 ~~~~~~
 
-This module would define three base classes for use with error handling. Unlike
+This module would define four base classes for use with error handling. Unlike
 many of the the other classes defined here, these classes are not abstract, as
 they have no behaviour. They exist simply to signal certain common behaviours.
 Backends should subclass these exceptions in their own packages, but needn't
@@ -971,6 +985,24 @@ The definitions of the errors are below::
         buffer-only I/O is used. This error signals that the requested
         operation cannot complete until more data is read from the network, or
         until more data is available in the input buffer.
+        """
+
+    class RaggedEOF(TLSError):
+        """
+        A special signaling exception used when a TLS connection has been
+        closed gracelessly: that is, when a TLS CloseNotify was not received
+        from the peer before the underlying TCP socket reached EOF. This is a
+        so-called "ragged EOF".
+
+        This exception is not guaranteed to be raised in the face of a ragged
+        EOF: some implementations may not be able to detect or report the
+        ragged EOF.
+
+        This exception is not always a problem. Ragged EOFs are a concern only
+        when protocols are vulnerable to length truncation attacks. Any
+        protocol that can detect length truncation attacks at the application
+        layer (e.g. HTTP/1.1 and HTTP/2) is not vulnerable to this kind of
+        attack and so can ignore this exception.
         """
 
 

--- a/pep-0xxx.rst
+++ b/pep-0xxx.rst
@@ -820,7 +820,7 @@ names of the cipher suites: that is, the cipher suite that OpenSSL calls
 The API for configuring cipher suites inside SecureTransport is simple::
 
     SSLCipherSuite ciphers[] = {TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384, ...};
-    OSStatus status = SSLSetEnabledCiphers(context, ciphers, sizeof(cphers));
+    OSStatus status = SSLSetEnabledCiphers(context, ciphers, sizeof(ciphers));
 
 SChannel
 ^^^^^^^^

--- a/pep-0xxx.rst
+++ b/pep-0xxx.rst
@@ -254,6 +254,19 @@ The ``Context`` abstract base class has the following class definition::
             """
             pass
 
+        @abstracmethod
+        def set_version_range(self, lower_bound=None: Optional[TLSVersion],
+                              upper_bound=None: Optional[TLSVersion]) -> None:
+            """
+            Set the minumum and maximum versions of TLS that should be allowed
+            on TLS connections made by this context.
+
+            If present, ``lower_bound`` will set the lowest acceptable TLS
+            version. If present, ``upper_bound`` will set the highest
+            acceptable TLS version. If either argument is ``None``, this will
+            leave that bound unchanged.
+            """
+
         @abstractmethod
         def wrap_socket(self, socket: socket.socket, server_side=False: bool,
                         auto_handshake=True: bool,
@@ -436,6 +449,12 @@ has the following definition::
             """
             pass
 
+        @abstractproperty
+        def negotiated_tls_version(self) -> Optional[TLSVersion]:
+            """
+            The version of TLS that has been negotiated on this connection.
+            """
+
 
 Buffer
 ~~~~~~
@@ -525,11 +544,47 @@ has the following definition::
             """
             pass
 
+        @abstractproperty
+        def negotiated_tls_version(self) -> Optional[TLSVersion]:
+            """
+            The version of TLS that has been negotiated on this connection.
+            """
+
 
 Cipher Suites
 ~~~~~~~~~~~~~
 
 Todo
+
+TLS Versions
+~~~~~~~~~~~~
+
+It is often useful to be able to restrict the versions of TLS you're willing to
+support. There are many security advantages in refusing to use old versions of
+TLS, and some misbehaving servers will mishandle TLS clients advertising
+support for newer versions.
+
+The following enumerated type can be used to gate TLS versions. Forward-looking
+applications should almost never set a maximum TLS version unless they
+absolutely must, as a TLS backend that is newer than the Python that uses it
+may support TLS versions that are not in this enumerated type.
+
+Additionally, this enumerated type defines two additional flags that can always
+be used to request either the lowest or highest TLS version supported by an
+implementation.
+
+::
+
+    class TLSVersion(Enum):
+        MINIMUM_SUPPORTED
+        SSLv2
+        SSLv3
+        TLSv1
+        TLSv1_1
+        TLSv1_2
+        TLSv1_3
+        MAXIMUM_SUPPORTED
+
 
 Errors
 ~~~~~~
@@ -607,7 +662,6 @@ ToDo
 * It's annoying that there's no type signature for fileobj. Do I really have to
   define one as part of this PEP? Otherwise, how do I define the types of the
   arguments to ``wrap_buffers``?
-* Do we need ways to disable specific TLS versions?
 * Do we need ways to control hostname validation?
 * Do we need ways to disable certificate validation altogether?
 * Do we need to support getpeercert? Should we always return DER instead of the

--- a/pep-0xxx.rst
+++ b/pep-0xxx.rst
@@ -288,51 +288,6 @@ The ``Context`` abstract base class has the following class definition::
             leave that bound unchanged.
             """
 
-        @abstractmethod
-        def wrap_socket(self, socket: socket.socket, server_side=False: bool,
-                        auto_handshake=True: bool,
-                        server_hostname=None: Optional[str]) -> TLSWrappedSocket:
-            """
-            Wrap an existing Python socket object ``socket`` and return a
-            ``TLSWrappedSocket`` object. ``socket`` must be a ``SOCK_STREAM``
-            socket: all other socket types are unsupported.
-
-            The returned SSL socket is tied to the context, its settings and
-            certificates.
-
-            The parameter ``server_side`` is a boolean which identifies whether
-            server-side or client-side behavior is desired from this socket.
-
-            The parameter ``auto_handshake`` specifies whether to do the SSL
-            handshake automatically after doing a ``socket.connect()``, or
-            whether the application program will call it explicitly, by
-            invoking the ``TLSWrappedSocket.do_handshake()`` method. Calling
-            ``TLSWrappedSocket.do_handshake()`` explicitly gives the program
-            control over the blocking behavior of the socket I/O involved in
-            the handshake.
-
-            On client connections, the optional parameter ``server_hostname``
-            specifies the hostname of the service which we are connecting to.
-            This allows a single server to host multiple SSL-based services
-            with distinct certificates, quite similarly to HTTP virtual hosts.
-            Specifying ``server_hostname`` will raise a ValueError if
-            ``server_side`` is ``True``.
-            """
-
-        @abstractmethod
-        def wrap_buffers(self, incoming: Any, outgoing: Any,
-                         server_side=False: bool,
-                         server_hostname=None: Optional[str]) -> TLSWrappedBuffer:
-            """
-            Wrap a pair of buffer objects (``incoming`` and ``outgoing``) to
-            create an in-memory stream for TLS. The SSL routines will read data
-            from ``incoming`` and decrypt it, and write encrypted data to
-            ``outgoing``.
-
-            The ``server_side`` and ``server_hostname`` parameters have the
-            same meaning as in ``wrap_socket``.
-            """
-
 
     class ClientContext(metaclass=ABCMeta):
         @abstractmethod

--- a/pep-0xxx.rst
+++ b/pep-0xxx.rst
@@ -200,7 +200,6 @@ The ``Context`` abstract base class has the following class definition::
             argument. It will be ignored if the private key is not encrypted
             and no password is needed.
             """
-            pass
 
         @abstractmethod
         def set_ciphers(self, ciphers: List[Ciphers]) -> None:
@@ -210,7 +209,6 @@ The ``Context`` abstract base class has the following class definition::
             ``Cipher`` registry. If none of the ``ciphers`` provided to this
             object are supported or available, a ``TLSError`` will be raised.
             """
-            pass
 
         @abstractmethod
         def set_inner_protocols(self, protocols: List[NextProtocol]) -> None:
@@ -228,7 +226,6 @@ The ``Context`` abstract base class has the following class definition::
             If the TLS implementation doesn't support protocol negotiation,
             this method will raise ``NotImplementedError``.
             """
-            pass
 
         @abstractmethod
         def set_sni_callback(self, callback: Optional[ServerNameCallback]) -> None:
@@ -255,7 +252,6 @@ The ``Context`` abstract base class has the following class definition::
             specified in this API, but is up to the concrete implementation to
             handle.
             """
-            pass
 
         @abstractmethod
         def set_version_range(self, lower_bound=None: Optional[TLSVersion],
@@ -300,7 +296,6 @@ The ``Context`` abstract base class has the following class definition::
             Specifying ``server_hostname`` will raise a ValueError if
             ``server_side`` is ``True``.
             """
-            pass
 
         @abstractmethod
         def wrap_buffers(self, incoming: Any, outgoing: Any,
@@ -315,7 +310,6 @@ The ``Context`` abstract base class has the following class definition::
             The ``server_side`` and ``server_hostname`` parameters have the
             same meaning as in ``wrap_socket``.
             """
-            pass
 
 
     class ClientContext(metaclass=ABCMeta):
@@ -344,7 +338,6 @@ The ``Context`` abstract base class has the following class definition::
             server to host multiple SSL-based services with distinct
             certificates, quite similarly to HTTP virtual hosts.
             """
-            pass
 
         @abstractmethod
         def wrap_buffers(self, incoming: Any, outgoing: Any,
@@ -358,7 +351,6 @@ The ``Context`` abstract base class has the following class definition::
             The ``server_hostname`` parameter has the same meaning as in
             ``wrap_socket``.
             """
-            pass
 
 
     class ServerContext(metaclass=ABCMeta):
@@ -381,7 +373,6 @@ The ``Context`` abstract base class has the following class definition::
             control over the blocking behavior of the socket I/O involved in
             the handshake.
             """
-            pass
 
         @abstractmethod
         def wrap_buffers(self, incoming: Any, outgoing: Any) -> TLSWrappedBuffer:
@@ -391,7 +382,6 @@ The ``Context`` abstract base class has the following class definition::
             from ``incoming`` and decrypt it, and write encrypted data to
             ``outgoing``.
             """
-            pass
 
 
 Socket
@@ -410,7 +400,6 @@ has the following definition::
             Performs the TLS handshake. Also performs certificate validation
             and hostname verification.
             """
-            pass
 
         @abstractmethod
         def cipher(self) -> Optional[Cipher]:
@@ -419,7 +408,6 @@ has the following definition::
             the connection. If no connection has been negotiated, returns
             ``None``.
             """
-            pass
 
         @abstractmethod
         def negotiated_protocol(self) -> Optional[NextProtocol]:
@@ -433,7 +421,6 @@ has the following definition::
             not support any of the peer's proposed protocols, or if the
             handshake has not happened yet, ``None`` is returned.
             """
-            pass
 
         @property
         @abstractmethod
@@ -441,7 +428,6 @@ has the following definition::
             """
             The ``Context`` object this socket is tied to.
             """
-            pass
 
         @context.setter
         @abstractmethod
@@ -450,7 +436,6 @@ has the following definition::
             Set the value of the ``Context`` object this socket is tied to.
             This operation (changing the context) may not always be supported.
             """
-            pass
 
         @abstractproperty
         def negotiated_tls_version(self) -> Optional[TLSVersion]:
@@ -481,7 +466,6 @@ has the following definition::
             As at any time a re-negotiation is possible, a call to ``read()``
             can also cause write operations.
             """
-            pass
 
         @abstractmethod
         def write(self, buf: Any) -> int:
@@ -497,7 +481,6 @@ has the following definition::
             As at any time a re-negotiation is possible, a call to ``write()``
             can also cause read operations.
             """
-            pass
 
         @abstractmethod
         def do_handshake(self) -> None:
@@ -505,7 +488,6 @@ has the following definition::
             Performs the TLS handshake. Also performs certificate validation
             and hostname verification.
             """
-            pass
 
         @abstractmethod
         def cipher(self) -> Optional[Cipher]:
@@ -514,7 +496,6 @@ has the following definition::
             the connection. If no connection has been negotiated, returns
             ``None``.
             """
-            pass
 
         @abstractmethod
         def negotiated_protocol(self) -> Optional[NextProtocol]:
@@ -528,7 +509,6 @@ has the following definition::
             not support any of the peer's proposed protocols, or if the
             handshake has not happened yet, ``None`` is returned.
             """
-            pass
 
         @property
         @abstractmethod
@@ -536,7 +516,6 @@ has the following definition::
             """
             The ``Context`` object this socket is tied to.
             """
-            pass
 
         @context.setter
         @abstractmethod
@@ -545,7 +524,6 @@ has the following definition::
             Set the value of the ``Context`` object this socket is tied to.
             This operation (changing the context) may not always be supported.
             """
-            pass
 
         @abstractproperty
         def negotiated_tls_version(self) -> Optional[TLSVersion]:
@@ -634,7 +612,6 @@ The definitions of the errors are below::
         Catching this error should be sufficient to catch *all* TLS errors,
         regardless of what backend is used.
         """
-        pass
 
     class WantWriteError(TLSError):
         """
@@ -643,7 +620,6 @@ The definitions of the errors are below::
         operation cannot complete until more data is written to the network,
         or until the output buffer is drained.
         """
-        pass
 
     class WantReadError(TLSError):
         """
@@ -652,7 +628,6 @@ The definitions of the errors are below::
         operation cannot complete until more data is read from the network, or
         until more data is available in the input buffer.
         """
-        pass
 
 Changes to the Standard Library
 ===============================

--- a/pep-0xxx.rst
+++ b/pep-0xxx.rst
@@ -1175,6 +1175,11 @@ but wherever possible features that are specific to individual implementations
 should not be added to the ABCs. The ABCs should restrict themselves to
 high-level descriptions of IETF-specified features.
 
+However, well-justified extensions to this API absolutely should be made. The
+focus of this API is to provide a unifying lowest-common-denominator
+configuration option for the Python community. TLS is not a static target, and
+as TLS evolves so must this API.
+
 
 References
 ==========

--- a/pep-0xxx.rst
+++ b/pep-0xxx.rst
@@ -235,6 +235,11 @@ changed under their feet, which allows them to avoid needing to carefully
 synchronize changes between their concrete data structures and the
 configuration object.
 
+This object is extendable: that is, future releases of Python may add
+configuration fields to this object as they become useful. For
+backwards-compatibility purposes, new fields are only appended to this object.
+Existing fields will never be removed, renamed, or reordered.
+
 The ``TLSConfiguration`` object would be defined by the following code:
 
     ServerNameCallback = Callable[[TLSBufferObject, Optional[str], TLSConfiguration], Any]

--- a/pep-0xxx.rst
+++ b/pep-0xxx.rst
@@ -347,14 +347,14 @@ The ``TLSConfiguration`` object would be defined by the following code::
         """
         __slots__ = ()
 
-        def __new__(cls, validate_certificates=None: Optional[bool],
-                         certificate_chain=None: Optional[Tuple[Tuple[Certificate], PrivateKey]],
-                         ciphers=None: Optional[Tuple[CipherSuite]],
-                         inner_protocols=None: Optional[Tuple[Union[NextProtocol, bytes]]],
-                         lowest_supported_version=None: Optional[TLSVersion],
-                         highest_supported_version=None: Optional[TLSVersion],
-                         trust_store=None: Optional[TrustStore],
-                         sni_callback=None: Optional[ServerNameCallback]):
+        def __new__(cls, validate_certificates: Optional[bool] = None,
+                         certificate_chain: Optional[Tuple[Tuple[Certificate], PrivateKey]] = None,
+                         ciphers: Optional[Tuple[CipherSuite]] = None,
+                         inner_protocols: Optional[Tuple[Union[NextProtocol, bytes]]] = None,
+                         lowest_supported_version: Optional[TLSVersion] = None,
+                         highest_supported_version: Optional[TLSVersion] = None,
+                         trust_store: Optional[TrustStore] = None,
+                         sni_callback: Optional[ServerNameCallback] = None):
 
             if validate_certificates is None:
                 validate_certificates = True
@@ -473,7 +473,7 @@ The ``Context`` abstract base class has the following class definition::
         def wrap_socket(self,
                         socket: socket.socket,
                         server_hostname: Optional[str],
-                        auto_handshake=True: bool) -> TLSWrappedSocket:
+                        auto_handshake: bool = True) -> TLSWrappedSocket:
             """
             Wrap an existing Python socket object ``socket`` and return a
             ``TLSWrappedSocket`` object. ``socket`` must be a ``SOCK_STREAM``
@@ -518,7 +518,7 @@ The ``Context`` abstract base class has the following class definition::
     class ServerContext(_BaseContext):
         @abstractmethod
         def wrap_socket(self, socket: socket.socket,
-                        auto_handshake=True: bool) -> TLSWrappedSocket:
+                        auto_handshake: bool = True) -> TLSWrappedSocket:
             """
             Wrap an existing Python socket object ``socket`` and return a
             ``TLSWrappedSocket`` object. ``socket`` must be a ``SOCK_STREAM``
@@ -622,7 +622,7 @@ has the following definition::
 
     class TLSWrappedBuffer(metaclass=ABCMeta):
         @abstractmethod
-        def read(self, amt=None: int) -> bytes:
+        def read(self, amt: int = None) -> bytes:
             """
             Read up to ``amt`` bytes of data from the input buffer and return
             the result as a ``bytes`` instance. If ``amt`` is ``None``, will
@@ -639,7 +639,7 @@ has the following definition::
             """
 
         @abstractmethod
-        def readinto(self, buffer: Any, amt=None: int) -> int:
+        def readinto(self, buffer: Any, amt: int = None) -> int:
             """
             Read up to ``amt`` bytes of data from the input buffer into
             ``buffer``, which must be an object that implements the buffer
@@ -1037,7 +1037,7 @@ This class has all the caveats of the ``Certificate`` class.
         @abstractclassmethod
         def from_buffer(cls,
                         buffer: bytes,
-                        password=None: Optional[Union[Callable[[], Union[bytes, bytearray]], bytes, bytearray]]) -> PrivateKey:
+                        password: Optional[Union[Callable[[], Union[bytes, bytearray]], bytes, bytearray]] = None) -> PrivateKey:
             """
             Creates a PrivateKey object from a byte buffer. This byte buffer
             may be either PEM-encoded or DER-encoded. If the buffer is PEM
@@ -1061,7 +1061,7 @@ This class has all the caveats of the ``Certificate`` class.
         @abstractclassmethod
         def from_file(cls,
                       path: Union[pathlib.Path, bytes, str],
-                      password=None: Optional[Union[Callable[[], Union[bytes, bytearray]], bytes, bytearray]]) -> PrivateKey:
+                      password: Optional[Union[Callable[[], Union[bytes, bytearray]], bytes, bytearray]] = None) -> PrivateKey:
             """
             Creates a PrivateKey object from a file on disk. This method may
             be a convenience method that wraps ``open`` and ``from_buffer``,

--- a/pep-0xxx.rst
+++ b/pep-0xxx.rst
@@ -1000,7 +1000,7 @@ an individual concrete implementation are also hashable.
 
     class Certificate(metaclass=ABCMeta):
         @abstractclassmethod
-        def from_buffer(cls, buffer: bytes) -> Certificate:
+        def from_buffer(cls, buffer: bytes):
             """
             Creates a Certificate object from a byte buffer. This byte buffer
             may be either PEM-encoded or DER-encoded. If the buffer is PEM
@@ -1012,7 +1012,7 @@ an individual concrete implementation are also hashable.
             """
 
         @abstractclassmethod
-        def from_file(cls, path: Union[pathlib.Path, AnyStr]) -> Certificate:
+        def from_file(cls, path: Union[pathlib.Path, AnyStr]):
             """
             Creates a Certificate object from a file on disk. This method may
             be a convenience method that wraps ``open`` and ``from_buffer``,
@@ -1037,7 +1037,7 @@ This class has all the caveats of the ``Certificate`` class.
         @abstractclassmethod
         def from_buffer(cls,
                         buffer: bytes,
-                        password: Optional[Union[Callable[[], Union[bytes, bytearray]], bytes, bytearray]] = None) -> PrivateKey:
+                        password: Optional[Union[Callable[[], Union[bytes, bytearray]], bytes, bytearray]] = None):
             """
             Creates a PrivateKey object from a byte buffer. This byte buffer
             may be either PEM-encoded or DER-encoded. If the buffer is PEM
@@ -1061,7 +1061,7 @@ This class has all the caveats of the ``Certificate`` class.
         @abstractclassmethod
         def from_file(cls,
                       path: Union[pathlib.Path, bytes, str],
-                      password: Optional[Union[Callable[[], Union[bytes, bytearray]], bytes, bytearray]] = None) -> PrivateKey:
+                      password: Optional[Union[Callable[[], Union[bytes, bytearray]], bytes, bytearray]] = None):
             """
             Creates a PrivateKey object from a file on disk. This method may
             be a convenience method that wraps ``open`` and ``from_buffer``,

--- a/pep-0xxx.rst
+++ b/pep-0xxx.rst
@@ -499,7 +499,7 @@ The ``Context`` abstract base class has the following class definition::
             certificates.
 
             The parameter ``auto_handshake`` specifies whether to do the SSL
-            handshake automatically after doing a ``socket.connect()``, or
+            handshake automatically after doing a ``socket.accept()``, or
             whether the application program will call it explicitly, by
             invoking the ``TLSWrappedSocket.do_handshake()`` method. Calling
             ``TLSWrappedSocket.do_handshake()`` explicitly gives the program

--- a/pep-0xxx.rst
+++ b/pep-0xxx.rst
@@ -210,6 +210,11 @@ for TLS configuration: the ``ClientContext`` and ``ServerContext`` objects are
 objects that are instantiated with a ``TLSConfiguration`` object. All three
 objects would be immutable.
 
+.. note:: The following API declarations uniformly use type hints to aid
+          reading. Some of these type hints cannot actually be used in practice
+          because they are circularly referential. Consider them more a
+          guideline than a reflection of the final code in the module.
+
 Configuration
 ~~~~~~~~~~~~~
 

--- a/pep-0xxx.rst
+++ b/pep-0xxx.rst
@@ -1,0 +1,571 @@
+PEP: XXX
+Title: TLS Abstract Base Classes
+Version: $Revision$
+Last-Modified: $Date$
+Author: Cory Benfield <cory@lukasa.co.uk>
+Status: Draft
+Type: Standards Track
+Content-Type: text/x-rst
+Created: 17-Oct-2016
+Python-Version: 3.7
+Post-History: 30-Aug-2002
+
+
+Abstract
+========
+
+This PEP would define a standard TLS interface in the form of a collection of
+abstract base classes. This interface would allow Python implementations and
+third-party libraries to provide bindings to TLS libraries other than OpenSSL
+that can be used by tools that expect the interface provided by the Python
+standard library, with the goal of reducing the dependence of the Python
+ecosystem on OpenSSL.
+
+
+Rationale
+=========
+
+In the 21st century it has become increasingly clear that robust and
+user-friendly TLS support is an extremely important part of the ecosystem of
+any popular programming language. For most of its lifetime, this role in the
+Python ecosystem has primarily been served by the `ssl module`_, which provides
+a Python API to the `OpenSSL library`_.
+
+Because the ``ssl`` module is distributed with the Python standard library, it
+has become the overwhelmingly most-popular method for handling TLS in Python.
+An extraordinary majority of Python libraries, both in the standard library and
+on the Python Package Index, rely on the ``ssl`` module for their TLS
+connectivity.
+
+Unfortunately, the preeminence of the ``ssl`` module has had a number of
+unforseen side-effects that have had the effect of tying the entire Python
+ecosystem tightly to OpenSSL. This has forced Python users to use OpenSSL even
+in situations where it may provide a worse user experience than alternative TLS
+implementations, which imposes a cognitive burden and makes it hard to provide
+"platform-native" experiences.
+
+
+Problems
+--------
+
+The fact that the ``ssl`` module is build into the standard library has meant
+that all standard-library Python networking libraries are entirely reliant on
+the OpenSSL that the Python implementation has been linked against. This
+leads to the following issues:
+
+* It is difficult to take advantage of new, higher-security TLS without
+  recompiling Python to get a new OpenSSL. While there are third-party bindings
+  to OpenSSL (e.g. `pyOpenSSL`_), these need to be shimmed into a format that
+  the standard library understands, forcing projects that want to use them to
+  maintain substantial compatibility layers.
+
+* For Windows distributions of Python, they need to be shipped with a copy of
+  OpenSSL. This puts the CPython development team in the position of being
+  OpenSSL redistributors, potentially needing to ship security updates to the
+  Windows Python distributions when OpenSSL vulnerabilities are released.
+
+* For macOS distributions of Python, they need either to be shipped with a copy
+  of OpenSSL or linked against the system OpenSSL library. Apple has formally
+  deprecated linking against the system OpenSSL library, and even if they had
+  not, that library version has been unsupported by upstream for nearly one
+  year as of the time of writing. The CPython development team has started
+  shipping newer OpenSSLs with the Python available from python.org, but this
+  has the same problem as with Windows.
+
+* Many systems, including but not limited to Windows and macOS, do not make
+  their system certificate stores available to OpenSSL. This forces users to
+  either obtain their trust roots from elsewhere (e.g. `certifi`_) or to
+  attempt to export their system trust stores in some form.
+
+  Relying on `certifi`_ is less than ideal, as most system administrators do
+  not expect to receive security-critical software updates from PyPI.
+  Additionally, it is not easy to extend the `certifi`_ trust bundle to include
+  custom roots, or to centrally manage trust using the `certifi`_ model.
+
+  Even in situations where the system certificate stores are made available to
+  OpenSSL in some form, the experience is still sub-standard, as OpenSSL will
+  perform different validation checks than the platform-native TLS
+  implementation. This can lead to users experiencing different behaviour on
+  their browsers or other platform-native tools than they experience in Python,
+  with little or no recourse to resolve the problem.
+
+* Users may wish to integrate with TLS libraries other than OpenSSL for many
+  other reasons, such as OpenSSL missing features (e.g. TLS 1.3 support), or
+  because OpenSSL is simply too large and unweildy for the platform (e.g. for
+  embedded Python). Those users are left with the requirement to use
+  third-party networking libraries that can interact with their preferred TLS
+  library or to shim their preferred library into the OpenSSL-specific ``ssl``
+  module API.
+
+Additionally, the ``ssl`` module as implemented today limits the ability of
+CPython itself to add support for alternative TLS backends, or remove OpenSSL
+support entirely, should either of these become necessary or useful. The
+``ssl`` module exposes too many OpenSSL-specific function calls and features to
+easily map to an alternative TLS backend.
+
+
+Proposal
+========
+
+This PEP proposes to introduce a few new Abstract Base Classes in Python 3.7 to
+provide TLS functionality that is not so strongly tied to OpenSSL. It also
+proposes to update standard library modules to use only the interface exposed
+by these abstract base classes wherever possible. There are three goals here:
+
+1. To provide a common API surface for both core and third-party developers to
+   target their TLS implementations to. This allows TLS developers to provide
+   interfaces that can be used by most Python code, and allows network
+   developers to have an interface that they can target that will work with a
+   wide range of TLS implementations.
+2. To provide an API that has few or no OpenSSL-specific concepts leak through.
+   The ``ssl`` module today has a number of warts caused by leaking OpenSSL
+   concepts through to the API: the new ABCs would remove those specific
+   concepts.
+3. To provide a path for the core development team to make OpenSSL one of many
+   possible TLS backends, rather than requiring that it be present on a system
+   in order for Python to have TLS support.
+
+The proposed interface is laid out below.
+
+
+Abstract Base Classes
+---------------------
+
+There are several interfaces that require standardisation. Those interfaces
+are:
+
+1. Configuring TLS, currently implemented by the `SSLContext`_ class in the
+   ``ssl`` module.
+2. Wrapping a socket object, currently implemented by the `SSLSocket`_ class
+   in the ``ssl`` module.
+3. Providing an in-memory buffer for doing in-memory encryption or decryption
+   with no actual I/O (necessary for asynchronous I/O models), currently
+   implemented by the `SSLObject`_ class in the ``ssl`` module.
+4. Specifying TLS cipher suites. There is currently no code for doing this in
+   the standard library: instead, the standard library uses OpenSSL cipher
+   suite strings.
+5. Reporting errors to the caller, currently implemented by the `SSLError`_
+   class in the ``ssl`` module.
+
+While it is technically possible to define (2) in terms of (3), for the sake of
+simplicity it is easier to define these as two separate ABCs. Impelementations
+are of course free to implement the concrete subclasses however they see fit.
+
+Obviously, (4) doesn't require an abstract base class: instead, it requires a
+richer API for configuring supported cipher suites that can be easily updated
+with supported cipher suites for different implementations.
+
+Context
+~~~~~~~
+
+The ``Context`` abstract base class defines an object that allows configuration
+of TLS. It can be thought of as a factory for ``TLSWrappedSocket`` and
+``TLSWrappedBuffer`` objects.
+
+The ``Context`` abstract base class has the following class definition::
+
+    TLSBufferObject = Union[TLSWrappedSocket, TLSWrappedBuffer]
+    ServerNameCallback = Callable[[TLSBufferObject, Optional[str], Context], Any]
+
+    class Context(metaclass=ABCMeta):
+        @abstractmethod
+        def register_certificates(self,
+                                  certificates: str,
+                                  key=None: Optional[str],
+                                  password=None: Optional[Callable[[], Union[AnyStr, bytearray]]]) -> None:
+            """
+            Loads a certificate, a number of intermediate certificates, and the
+            corresponding private key. These certificates will be offered to
+            the remote peer during the handshake if required.
+
+            The ``certificates`` argument must be a bytestring containing the
+            PEM-encoded certificates. The first PEM-encoded certificate must be
+            the leaf certificate. All subsequence certificates will be offered
+            as intermediate additional certificates.
+
+            The ``key`` argument, if present, must contain the PEM-encoded
+            private key associated with the leaf certificate. If not present,
+            the private key will be extracted from ``certificates``.
+
+            The ``password`` argument may be a function to call to get the
+            password for decrypting the private key. It will only be called if
+            the private key is encrypted and a password is necessary. It will
+            be called with no arguments, and it should return a string, bytes,
+            or bytearray. If the return value is a string it will be encoded as
+            UTF-8 before using it to decrypt the key. Alternatively a string,
+            bytes, or bytearray value may be supplied directly as the password
+            argument. It will be ignored if the private key is not encrypted
+            and no password is needed.
+            """
+            pass
+
+        @abstractmethod
+        def set_ciphers(self, ciphers: List[Ciphers]) -> None:
+            """
+            Set the available ciphers for TLS connections created with this
+            context. ``ciphers`` should be a list of ciphers from the
+            ``Cipher`` registry. If none of the ``ciphers`` provided to this
+            object are supported or available, a ``TLSError`` will be raised.
+            """
+            pass
+
+        @abstractmethod
+        def set_inner_protocols(self, protocols: List[str]) -> None:
+            """
+            Specify which protocols the socket should advertise as supported
+            during the TLS handshake. This may be advertised using either or
+            both of ALPN or NPN.
+
+            ``protocols`` should be a list of ASCII strings for ALPN tokens,
+            such as ``['h2', 'http/1.1']``, ordered by preference. The
+            selection of the protocol will happen during the handshake, and
+            will use whatever protocol negotiation mechanisms are available and
+            supported by both peers.
+
+            If the TLS implementation doesn't support protocol negotiation,
+            this method will raise ``NotImplementedError``.
+            """
+            pass
+
+        @abstractmethod
+        def set_sni_callback(self, callback: Optional[ServerNameCallback]) -> None:
+            """
+            Register a callback function that will be called after the TLS
+            Client Hello handshake message has been received by the TLS server
+            when the TLS client specifies a server name indication.
+
+            Only one callback can be set per ``Context``. If ``callback`` is
+            ``None`` then the callback is disabled. Calling this function a
+            subsequent time will disable the previously registered callback.
+
+            The ``callback`` function will be called with three arguments: the
+            first will be the ``TLSBufferObject`` for the connection; the
+            second will be a string that represents the server name that the
+            client is intending to communicate (or ``None`` if the TLS Client
+            Hello does not contain a server name); and the third argument will
+            be the original ``Context``. The server name argument will be the
+            IDNA *decoded* server name.
+
+            The ``callback`` must return ``None`` to allow negotiation to
+            continue. Other return values signal errors. Attempting to control
+            what error is signaled by the underlying TLS implementation is not
+            specified in this API, but is up to the concrete implementation to
+            handle.
+            """
+            pass
+
+        @abstractmethod
+        def wrap_socket(self, socket: socket.socket, server_side=False: bool,
+                        auto_handshake=True: bool,
+                        server_hostname=None: Optional[str]) -> TLSWrappedSocket:
+            """
+            Wrap an existing Python socket object ``socket`` and return a
+            ``TLSWrappedSocket`` object. ``socket`` must be a ``SOCK_STREAM``
+            socket: all other socket types are unsupported.
+
+            The returned SSL socket is tied to the context, its settings and
+            certificates.
+
+            The parameter ``server_side`` is a boolean which identifies whether
+            server-side or client-side behavior is desired from this socket.
+
+            The parameter ``auto_handshake`` specifies whether to do the SSL
+            handshake automatically after doing a ``socket.connect()``, or
+            whether the application program will call it explicitly, by
+            invoking the ``TLSWrappedSocket.do_handshake()`` method. Calling
+            ``TLSWrappedSocket.do_handshake()`` explicitly gives the program
+            control over the blocking behavior of the socket I/O involved in
+            the handshake.
+
+            On client connections, the optional parameter ``server_hostname``
+            specifies the hostname of the service which we are connecting to.
+            This allows a single server to host multiple SSL-based services
+            with distinct certificates, quite similarly to HTTP virtual hosts.
+            Specifying ``server_hostname`` will raise a ValueError if
+            ``server_side`` is ``True``.
+            """
+            pass
+
+        @abstractmethod
+        def wrap_buffers(self, incoming: Any, outgoing: Any,
+                         server_side=False: bool,
+                         server_hostname=None: Optional[str]) -> TLSWrappedBuffer:
+            """
+            Wrap a pair of buffer objects (``incoming`` and ``outgoing``) to
+            create an in-memory stream for TLS. The SSL routines will read data
+            from ``incoming`` and decrypt it, and write encrypted data to
+            ``outgoing``.
+
+            The ``server_side`` and ``server_hostname`` parameters have the
+            same meaning as in ``wrap_socket``.
+            """
+            pass
+
+
+Socket
+~~~~~~
+
+The socket-wrapper ABC will be defined by the ``TLSWrappedSocket`` ABC, which
+has the following definition::
+
+    class TLSWrappedSocket(metaclass=ABCMeta):
+        # The various socket methods all must be implemented. Their definitions
+        # have been elided from this class defintion in the PEP because they
+        # aren't instructive.
+        @abstractmethod
+        def do_handshake(self) -> None:
+            """
+            Performs the TLS handshake. Also performs certificate validation
+            and hostname verification.
+            """
+            pass
+
+        @abstractmethod
+        def cipher(self) -> Optional[Cipher]:
+            """
+            Returns the Cipher entry for the cipher that has been negotiated on
+            the connection. If no connection has been negotiated, returns
+            ``None``.
+            """
+            pass
+
+        @abstractmethod
+        def negotiated_protocol(self) -> Optional[str]:
+            """
+            Returns the protocol that was selected during the TLS handshake.
+            This selection may have been made using ALPN, NPN, or some future
+            negotiation mechanism.
+
+            If ``Context.set_inner_protocols()`` was not called, if the other
+            party does not support protocol negotiation, if this socket does
+            not support any of the peer's proposed protocols, or if the
+            handshake has not happened yet, ``None`` is returned.
+            """
+            pass
+
+        @property
+        @abstractmethod
+        def context(self) -> Context:
+            """
+            The ``Context`` object this socket is tied to.
+            """
+            pass
+
+        @context.setter
+        @abstractmethod
+        def context(self, value: Context) -> None:
+            """
+            Set the value of the ``Context`` object this socket is tied to.
+            This operation (changing the context) may not always be supported.
+            """
+            pass
+
+
+Buffer
+~~~~~~
+
+The buffer-wrapper ABC will be defined by the ``TLSWrappedBuffer`` ABC, which
+has the following definition::
+
+    class TLSWrappedBuffer(metaclass=ABCMeta):
+        @abstractmethod
+        def read(self, len=1024: int, buffer=None: Any) -> Union[bytes, int]:
+            """
+            Read up to ``len`` bytes of data from the input buffer and return
+            the result as a ``bytes`` instance. If ``buffer`` is specified,
+            then read into the buffer instead, and return the number of bytes
+            read.
+
+            Raise ``WantReadError`` or ``WantWriteError`` if there is
+            insufficient data in either the input or output buffer and the
+            operation would have caused data to be written or read.
+
+            As at any time a re-negotiation is possible, a call to ``read()``
+            can also cause write operations.
+            """
+            pass
+
+        @abstractmethod
+        def write(self, buf: Any) -> int:
+            """
+            Write ``buf`` in encrypted form to the output buffer and return the
+            number of bytes written. The ``buf`` argument must be an object
+            supporting the buffer interface.
+
+            Raise ``WantReadError`` or ``WantWriteError`` if there is
+            insufficient data in either the input or output buffer and the
+            operation would have caused data to be written or read.
+
+            As at any time a re-negotiation is possible, a call to ``write()``
+            can also cause read operations.
+            """
+            pass
+
+        @abstractmethod
+        def do_handshake(self) -> None:
+            """
+            Performs the TLS handshake. Also performs certificate validation
+            and hostname verification.
+            """
+            pass
+
+        @abstractmethod
+        def cipher(self) -> Optional[Cipher]:
+            """
+            Returns the Cipher entry for the cipher that has been negotiated on
+            the connection. If no connection has been negotiated, returns
+            ``None``.
+            """
+            pass
+
+        @abstractmethod
+        def negotiated_protocol(self) -> Optional[str]:
+            """
+            Returns the protocol that was selected during the TLS handshake.
+            This selection may have been made using ALPN, NPN, or some future
+            negotiation mechanism.
+
+            If ``Context.set_inner_protocols()`` was not called, if the other
+            party does not support protocol negotiation, if this socket does
+            not support any of the peer's proposed protocols, or if the
+            handshake has not happened yet, ``None`` is returned.
+            """
+            pass
+
+        @property
+        @abstractmethod
+        def context(self) -> Context:
+            """
+            The ``Context`` object this socket is tied to.
+            """
+            pass
+
+        @context.setter
+        @abstractmethod
+        def context(self, value: Context) -> None:
+            """
+            Set the value of the ``Context`` object this socket is tied to.
+            This operation (changing the context) may not always be supported.
+            """
+            pass
+
+
+Cipher Suites
+~~~~~~~~~~~~~
+
+Todo
+
+Errors
+~~~~~~
+
+This module would define three base classes for use with error handling. Unlike
+the other classes defined here, these classes are not *abstract*, as they have
+no behaviour. They exist simply to signal certain common behaviours. Backends
+should subclass these exceptions in their own packages, but needn't define any
+behaviour for them. These exceptions should *never* be thrown directly, they
+should always be subclassed.
+
+The definitions of the errors are below::
+
+    class TLSError(Exception):
+        """
+        The base exception for all TLS related errors from any backend.
+        Catching this error should be sufficient to catch *all* TLS errors,
+        regardless of what backend is used.
+        """
+        pass
+
+    class WantWriteError(TLSError):
+        """
+        A special signaling exception used only when non-blocking or
+        buffer-only I/O is used. This error signals that the requested
+        operation cannot complete until more data is written to the network,
+        or until the output buffer is drained.
+        """
+        pass
+
+    class WantReadError(TLSError):
+        """
+        A special signaling exception used only when non-blocking or
+        buffer-only I/O is used. This error signals that the requested
+        operation cannot complete until more data is read from the network, or
+        until more data is available in the input buffer.
+        """
+        pass
+
+Changes to the Standard Library
+===============================
+
+The portions of the standard library that interact with TLS should be revised
+to use these ABCs. This will allow them to function with other TLS backends.
+This includes the following modules:
+
+- asyncio
+- ftplib
+- http.client
+- imaplib
+- nntplib
+- poplib
+- smtplib
+
+
+Future
+======
+
+Major future TLS features may require revisions of these ABCs. These revisions
+should be made cautiously: many backends may not be able to move forward
+swiftly, and will be invalidated by changes in these ABCs. This is acceptable,
+but wherever possible features that are specific to individual implementations
+should not be added to the ABCs. The ABCs should restrict themselves to
+high-level descriptions of IETF-specified features.
+
+
+ToDo
+====
+
+* Consider adding a new parameter (``valid_subjects``?) to ``wrap_socket`` and
+  ``wrap_buffers`` that specifies in a *typed* manner what kind of entries in
+  the SAN field are acceptable. This would break the union between SNI and
+  cert validation, which may be a good thing (you can't SNI an IP address, but
+  you can validate a cert with one if you want).
+* It's annoying that there's no type signature for fileobj. Do I really have to
+  define one as part of this PEP? Otherwise, how do I define the types of the
+  arguments to ``wrap_buffers``?
+* Do we need ways to disable specific TLS versions?
+* Do we need ways to control hostname validation?
+* Do we need ways to disable certificate validation altogether?
+* Do we need to support getpeercert? Should we always return DER instead of the
+  weird semi-structured thing?
+* How do we load certs from locations on disk?
+* How do we signal to load certs from the OS? What happens if an implementation
+  doesn't let you *not* load those certs?
+
+
+References
+==========
+
+.. _ssl module: https://docs.python.org/3/library/ssl.html
+.. _OpenSSL Library: https://www.openssl.org/
+.. _PyOpenSSL: https://pypi.org/project/pyOpenSSL/
+.. _certifi: https://pypi.org/project/certifi/
+.. _SSLContext: https://docs.python.org/3/library/ssl.html#ssl.SSLContext
+.. _SSLSocket: https://docs.python.org/3/library/ssl.html#ssl.SSLSocket
+.. _SSLObject: https://docs.python.org/3/library/ssl.html#ssl.SSLObject
+.. _SSLError: https://docs.python.org/3/library/ssl.html#ssl.SSLError
+
+
+Copyright
+=========
+
+This document has been placed in the public domain.
+
+
+
+..
+   Local Variables:
+   mode: indented-text
+   indent-tabs-mode: nil
+   sentence-end-double-space: t
+   fill-column: 70
+   coding: utf-8
+   End:

--- a/pep-0xxx.rst
+++ b/pep-0xxx.rst
@@ -671,7 +671,7 @@ ToDo
 * Do we need ways to disable certificate validation altogether?
 * Do we need to support getpeercert? Should we always return DER instead of the
   weird semi-structured thing?
-* How do we load certs from locations on disk?
+* How do we load certs from locations on disk? What about HSMs?
 * How do we signal to load certs from the OS? What happens if an implementation
   doesn't let you *not* load those certs?
 

--- a/pep-0xxx.rst
+++ b/pep-0xxx.rst
@@ -500,6 +500,9 @@ The ``Context`` abstract base class has the following class definition::
             from ``incoming`` and decrypt it, and write encrypted data to
             ``outgoing``.
 
+            The buffer objects must be either file objects or objects that
+            implement the buffer protocol.
+
             The ``server_hostname`` parameter has the same meaning as in
             ``wrap_socket``.
             """
@@ -533,6 +536,9 @@ The ``Context`` abstract base class has the following class definition::
             create an in-memory stream for TLS. The SSL routines will read data
             from ``incoming`` and decrypt it, and write encrypted data to
             ``outgoing``.
+
+            The buffer objects must be either file objects or objects that
+            implement the buffer protocol.
             """
 
 
@@ -1128,9 +1134,6 @@ ToDo
   the SAN field are acceptable. This would break the union between SNI and
   cert validation, which may be a good thing (you can't SNI an IP address, but
   you can validate a cert with one if you want).
-* It's annoying that there's no type signature for fileobj. Do I really have to
-  define one as part of this PEP? Otherwise, how do I define the types of the
-  arguments to ``wrap_buffers``?
 * Do we need ways to control hostname validation?
 * Do we need to support getpeercert? Should we always return DER instead of the
   weird semi-structured thing?

--- a/pep-0xxx.rst
+++ b/pep-0xxx.rst
@@ -607,7 +607,7 @@ has the following definition::
             """
 
         @abstractmethod
-        def read_into(self, buffer: Any, amt=None: int) -> int:
+        def readinto(self, buffer: Any, amt=None: int) -> int:
             """
             Read up to ``amt`` bytes of data from the input buffer into
             ``buffer``, which must be an object that implements the buffer
@@ -621,7 +621,7 @@ has the following definition::
             operation would have caused data to be written or read.
 
             As at any time a re-negotiation is possible, a call to
-            ``read_into()`` can also cause write operations.
+            ``readinto()`` can also cause write operations.
             """
 
         @abstractmethod

--- a/pep-0xxx.rst
+++ b/pep-0xxx.rst
@@ -417,9 +417,23 @@ The ``TLSConfiguration`` object would be defined by the following code:
 Context
 ~~~~~~~
 
-The ``Context`` abstract base class defines an object that allows configuration
-of TLS. It can be thought of as a factory for ``TLSWrappedSocket`` and
-``TLSWrappedBuffer`` objects.
+We define two Context abstract base classes. These ABCs define objects that
+allow configuration of TLS to be applied to specific connections. They can be
+thought of as factories for ``TLSWrappedSocket`` and ``TLSWrappedBuffer``
+objects.
+
+Unlike the current ``ssl`` module, we provide two context classes instead of
+one. Specifically, we provide the ``ClientContext`` and ``ServerContext``
+classes. This simplifies the APIs (for example, there is no sense in the server
+providing the ``server_hostname`` parameter to ``ssl.SSLContext.wrap_socket``,
+but because there is only one context class that parameter is still available),
+and ensures that implementations know as early as possible which side of a TLS
+connection they will serve. Additionally, it allows implementations to opt-out
+of one or either side of the connection. For example, SChannel on macOS is not
+really intended for server use and has an enormous amount of functionality
+missing for server-side use. This would allow SChannel implementations to
+simply not define a concrete subclass of ``ServerContext`` to signal their lack
+of support.
 
 As much as possible implementers should aim to make these classes immutable:
 that is, they should prefer not to allow users to mutate their internal state

--- a/pep-0xxx.rst
+++ b/pep-0xxx.rst
@@ -430,11 +430,11 @@ providing the ``server_hostname`` parameter to ``ssl.SSLContext.wrap_socket``,
 but because there is only one context class that parameter is still available),
 and ensures that implementations know as early as possible which side of a TLS
 connection they will serve. Additionally, it allows implementations to opt-out
-of one or either side of the connection. For example, SChannel on macOS is not
-really intended for server use and has an enormous amount of functionality
-missing for server-side use. This would allow SChannel implementations to
-simply not define a concrete subclass of ``ServerContext`` to signal their lack
-of support.
+of one or either side of the connection. For example, SecureTransport on macOS
+is not really intended for server use and has an enormous amount of
+functionality missing for server-side use. This would allow SecureTransport
+implementations to simply not define a concrete subclass of ``ServerContext``
+to signal their lack of support.
 
 As much as possible implementers should aim to make these classes immutable:
 that is, they should prefer not to allow users to mutate their internal state

--- a/pep-0xxx.rst
+++ b/pep-0xxx.rst
@@ -272,7 +272,7 @@ The ``TLSConfiguration`` object would be defined by the following code:
             will throw a ``TLSError`` when this object is passed into a
             context object.
 
-        :param certificate_chain Tuple[List[Certificate],PrivateKey]: The
+        :param certificate_chain Tuple[Tuple[Certificate],PrivateKey]: The
             certificate, intermediate certificate, and the corresponding
             private key for the leaf certificate. These certificates will be
             offered to the remote peer during the handshake if required.
@@ -281,11 +281,11 @@ The ``TLSConfiguration`` object would be defined by the following code:
             subsequent certificates will be offered as intermediate additional
             certificates.
 
-        :param ciphers List[CipherSuite]:
+        :param ciphers Tuple[CipherSuite]:
             The available ciphers for TLS connections created with this
             configuration, in priority order.
 
-        :param inner_protocols List[Union[NextProtocol, bytes]]:
+        :param inner_protocols Tuple[Union[NextProtocol, bytes]]:
             Protocols that connections created with this configuration should
             advertise as supported during the TLS handshake. These may be
             advertised using either or both of ALPN or NPN. This list of
@@ -336,9 +336,9 @@ The ``TLSConfiguration`` object would be defined by the following code:
         __slots__ = ()
 
         def __new__(cls, validate_certificates=None: Optional[bool],
-                         certificate_chain=None: Optional[Tuple[List[Certificate], PrivateKey]],
-                         ciphers=None: Optional[List[CipherSuite]],
-                         inner_protocols=None: Optional[List[Union[NextProtocol, bytes]]],
+                         certificate_chain=None: Optional[Tuple[Tuple[Certificate], PrivateKey]],
+                         ciphers=None: Optional[Tuple[CipherSuite]],
+                         inner_protocols=None: Optional[Tuple[Union[NextProtocol, bytes]]],
                          lowest_supported_version=None: Optional[TLSVersion],
                          highest_supported_version=None: Optional[TLSVersion],
                          trust_store=None: Optional[TrustStore],

--- a/pep-0xxx.rst
+++ b/pep-0xxx.rst
@@ -444,9 +444,10 @@ The ``Context`` abstract base class has the following class definition::
 
     class ClientContext(_BaseContext):
         @abstractmethod
-        def wrap_socket(self, socket: socket.socket,
-                        auto_handshake=True: bool,
-                        server_hostname=None: Optional[str]) -> TLSWrappedSocket:
+        def wrap_socket(self,
+                        socket: socket.socket,
+                        server_hostname: Optional[str],
+                        auto_handshake=True: bool) -> TLSWrappedSocket:
             """
             Wrap an existing Python socket object ``socket`` and return a
             ``TLSWrappedSocket`` object. ``socket`` must be a ``SOCK_STREAM``
@@ -455,6 +456,13 @@ The ``Context`` abstract base class has the following class definition::
             The returned SSL socket is tied to the context, its settings and
             certificates.
 
+            The parameter ``server_hostname`` specifies the hostname of the
+            service which we are connecting to. This allows a single server to
+            host multiple SSL-based services with distinct certificates, quite
+            similarly to HTTP virtual hosts. This is also used to validate the
+            TLS certificate for the given hostname. If hostname validation is
+            not desired, then pass ``None`` for this parameter.
+
             The parameter ``auto_handshake`` specifies whether to do the SSL
             handshake automatically after doing a ``socket.connect()``, or
             whether the application program will call it explicitly, by
@@ -462,16 +470,11 @@ The ``Context`` abstract base class has the following class definition::
             ``TLSWrappedSocket.do_handshake()`` explicitly gives the program
             control over the blocking behavior of the socket I/O involved in
             the handshake.
-
-            The optional parameter ``server_hostname`` specifies the hostname
-            of the service which we are connecting to. This allows a single
-            server to host multiple SSL-based services with distinct
-            certificates, quite similarly to HTTP virtual hosts.
             """
 
         @abstractmethod
         def wrap_buffers(self, incoming: Any, outgoing: Any,
-                         server_hostname=None: Optional[str]) -> TLSWrappedBuffer:
+                         server_hostname: Optional[str]) -> TLSWrappedBuffer:
             """
             Wrap a pair of buffer objects (``incoming`` and ``outgoing``) to
             create an in-memory stream for TLS. The SSL routines will read data

--- a/pep-0xxx.rst
+++ b/pep-0xxx.rst
@@ -901,10 +901,10 @@ Errors
 ~~~~~~
 
 This module would define three base classes for use with error handling. Unlike
-the other classes defined here, these classes are not *abstract*, as they have
-no behaviour. They exist simply to signal certain common behaviours. Backends
-should subclass these exceptions in their own packages, but needn't define any
-behaviour for them.
+many of the the other classes defined here, these classes are not abstract, as
+they have no behaviour. They exist simply to signal certain common behaviours.
+Backends should subclass these exceptions in their own packages, but needn't
+define any behaviour for them.
 
 In general, concrete implementations should subclass these exceptions rather
 than throw them directly. This makes it moderately easier to determine which

--- a/pep-0xxx.rst
+++ b/pep-0xxx.rst
@@ -289,7 +289,7 @@ The ``Context`` abstract base class has the following class definition::
             """
 
 
-    class ClientContext(metaclass=ABCMeta):
+    class ClientContext(_BaseContext):
         @abstractmethod
         def wrap_socket(self, socket: socket.socket,
                         auto_handshake=True: bool,
@@ -330,7 +330,7 @@ The ``Context`` abstract base class has the following class definition::
             """
 
 
-    class ServerContext(metaclass=ABCMeta):
+    class ServerContext(_BaseContext):
         @abstractmethod
         def wrap_socket(self, socket: socket.socket,
                         auto_handshake=True: bool) -> TLSWrappedSocket:

--- a/pep-0xxx.rst
+++ b/pep-0xxx.rst
@@ -955,6 +955,10 @@ to load certificates from HSMs. If a common interface emerges for doing this,
 this module may be updated to provide a standard constructor for this use-case
 as well.
 
+Concrete implementations should aim to have Certificate objects be hashable if
+at all possible. This will help ensure that TLSConfiguration objects used with
+an individual concrete implementation are also hashable.
+
     class Certificate(metaclass=ABCMeta):
         @abstractclassmethod
         def from_buffer(cls, buffer: bytes) -> Certificate:
@@ -1047,6 +1051,10 @@ constructors. However, it is strongly recommended that a given TLS
 implementation provide the ``system`` constructor if at all possible, as this
 is the most common validation trust store that is used. Concrete
 implementations may also add their own constructors.
+
+Concrete implementations should aim to have TrustStore objects be hashable if
+at all possible. This will help ensure that TLSConfiguration objects used with
+an individual concrete implementation are also hashable.
 
     class TrustStore(metaclass=ABCMeta):
         @abstractclassmethod

--- a/pep-0xxx.rst
+++ b/pep-0xxx.rst
@@ -148,7 +148,7 @@ are:
    class in the ``ssl`` module.
 
 While it is technically possible to define (2) in terms of (3), for the sake of
-simplicity it is easier to define these as two separate ABCs. Impelementations
+simplicity it is easier to define these as two separate ABCs. Implementations
 are of course free to implement the concrete subclasses however they see fit.
 
 Obviously, (4) doesn't require an abstract base class: instead, it requires a

--- a/pep-0xxx.rst
+++ b/pep-0xxx.rst
@@ -623,8 +623,12 @@ This module would define three base classes for use with error handling. Unlike
 the other classes defined here, these classes are not *abstract*, as they have
 no behaviour. They exist simply to signal certain common behaviours. Backends
 should subclass these exceptions in their own packages, but needn't define any
-behaviour for them. These exceptions should *never* be thrown directly, they
-should always be subclassed.
+behaviour for them.
+
+In general, concrete implementations should subclass these exceptions rather
+than throw them directly. This makes it moderately easier to determine which
+concrete TLS implementation is in use during debugging of unexpected errors.
+However, this is not mandatory.
 
 The definitions of the errors are below::
 

--- a/pep-0xxx.rst
+++ b/pep-0xxx.rst
@@ -48,7 +48,7 @@ implementations, which imposes a cognitive burden and makes it hard to provide
 Problems
 --------
 
-The fact that the ``ssl`` module is build into the standard library has meant
+The fact that the ``ssl`` module is built into the standard library has meant
 that all standard-library Python networking libraries are entirely reliant on
 the OpenSSL that the Python implementation has been linked against. This
 leads to the following issues:
@@ -91,7 +91,7 @@ leads to the following issues:
 
 * Users may wish to integrate with TLS libraries other than OpenSSL for many
   other reasons, such as OpenSSL missing features (e.g. TLS 1.3 support), or
-  because OpenSSL is simply too large and unweildy for the platform (e.g. for
+  because OpenSSL is simply too large and unwieldy for the platform (e.g. for
   embedded Python). Those users are left with the requirement to use
   third-party networking libraries that can interact with their preferred TLS
   library or to shim their preferred library into the OpenSSL-specific ``ssl``
@@ -164,7 +164,7 @@ Obviously, (5) doesn't require an abstract base class: instead, it requires a
 richer API for configuring supported cipher suites that can be easily updated
 with supported cipher suites for different implementations.
 
-(9) is a thorny problem, becuase in an ideal world the private keys associated
+(9) is a thorny problem, because in an ideal world the private keys associated
 with these certificates would never end up in-memory in the Python process
 (that is, the TLS library would collaborate with a Hardware Security Module
 (HSM) to provide the private key in such a way that it cannot be extracted from
@@ -551,7 +551,7 @@ has the following definition::
 
     class TLSWrappedSocket(metaclass=ABCMeta):
         # The various socket methods all must be implemented. Their definitions
-        # have been elided from this class defintion in the PEP because they
+        # have been elided from this class definition in the PEP because they
         # aren't instructive.
         @abstractmethod
         def do_handshake(self) -> None:

--- a/pep-0xxx.rst
+++ b/pep-0xxx.rst
@@ -437,12 +437,13 @@ has the following definition::
 
     class TLSWrappedBuffer(metaclass=ABCMeta):
         @abstractmethod
-        def read(self, len=1024: int, buffer=None: Any) -> Union[bytes, int]:
+        def read(self, amt=None: int) -> bytes:
             """
-            Read up to ``len`` bytes of data from the input buffer and return
-            the result as a ``bytes`` instance. If ``buffer`` is specified,
-            then read into the buffer instead, and return the number of bytes
-            read.
+            Read up to ``amt`` bytes of data from the input buffer and return
+            the result as a ``bytes`` instance. If ``amt`` is ``None``, will
+            attempt to read until either EOF is reached or until further
+            attempts to read would raise either ``WantReadError`` or
+            ``WantWriteError``.
 
             Raise ``WantReadError`` or ``WantWriteError`` if there is
             insufficient data in either the input or output buffer and the
@@ -450,6 +451,24 @@ has the following definition::
 
             As at any time a re-negotiation is possible, a call to ``read()``
             can also cause write operations.
+            """
+
+        @abstractmethod
+        def read_into(self, buffer: Any, amt=None: int) -> int:
+            """
+            Read up to ``amt`` bytes of data from the input buffer into
+            ``buffer``, which must be an object that implements the buffer
+            protocol. Returns the number of bytes read. If ``amt`` is ``None``,
+            will attempt to read until either EOF is reached or until further
+            attempts to read would raise either ``WantReadError`` or
+            ``WantWriteError``, or until the buffer is full.
+
+            Raises ``WantReadError`` or ``WantWriteError`` if there is
+            insufficient data in either the input or output buffer and the
+            operation would have caused data to be written or read.
+
+            As at any time a re-negotiation is possible, a call to
+            ``read_into()`` can also cause write operations.
             """
 
         @abstractmethod

--- a/pep-0xxx.rst
+++ b/pep-0xxx.rst
@@ -1126,22 +1126,6 @@ should not be added to the ABCs. The ABCs should restrict themselves to
 high-level descriptions of IETF-specified features.
 
 
-ToDo
-====
-
-* Consider adding a new parameter (``valid_subjects``?) to ``wrap_socket`` and
-  ``wrap_buffers`` that specifies in a *typed* manner what kind of entries in
-  the SAN field are acceptable. This would break the union between SNI and
-  cert validation, which may be a good thing (you can't SNI an IP address, but
-  you can validate a cert with one if you want).
-* Do we need ways to control hostname validation?
-* Do we need to support getpeercert? Should we always return DER instead of the
-  weird semi-structured thing?
-* How do we load certs from locations on disk? What about HSMs?
-* How do we signal to load certs from the OS? What happens if an implementation
-  doesn't let you *not* load those certs?
-
-
 References
 ==========
 

--- a/pep-0xxx.rst
+++ b/pep-0xxx.rst
@@ -38,7 +38,7 @@ on the Python Package Index, rely on the ``ssl`` module for their TLS
 connectivity.
 
 Unfortunately, the preeminence of the ``ssl`` module has had a number of
-unforseen side-effects that have had the effect of tying the entire Python
+unforeseen side-effects that have had the effect of tying the entire Python
 ecosystem tightly to OpenSSL. This has forced Python users to use OpenSSL even
 in situations where it may provide a worse user experience than alternative TLS
 implementations, which imposes a cognitive burden and makes it hard to provide
@@ -257,7 +257,7 @@ The ``TLSConfiguration`` object would be defined by the following code:
 
     class TLSConfiguration(namedtuple('TLSConfiguration', _configuration_fields)):
         """
-        An imutable TLS Configuration object. This object has the following
+        An immutable TLS Configuration object. This object has the following
         properties:
 
         :param validate_certificates bool: Whether to validate the TLS

--- a/pep-0xxx.rst
+++ b/pep-0xxx.rst
@@ -253,32 +253,6 @@ The ``Context`` abstract base class has the following class definition::
             """
 
         @abstractmethod
-        def set_sni_callback(self, callback: Optional[ServerNameCallback]) -> None:
-            """
-            Register a callback function that will be called after the TLS
-            Client Hello handshake message has been received by the TLS server
-            when the TLS client specifies a server name indication.
-
-            Only one callback can be set per ``Context``. If ``callback`` is
-            ``None`` then the callback is disabled. Calling this function a
-            subsequent time will disable the previously registered callback.
-
-            The ``callback`` function will be called with three arguments: the
-            first will be the ``TLSBufferObject`` for the connection; the
-            second will be a string that represents the server name that the
-            client is intending to communicate (or ``None`` if the TLS Client
-            Hello does not contain a server name); and the third argument will
-            be the original ``Context``. The server name argument will be the
-            IDNA *decoded* server name.
-
-            The ``callback`` must return ``None`` to allow negotiation to
-            continue. Other return values signal errors. Attempting to control
-            what error is signaled by the underlying TLS implementation is not
-            specified in this API, but is up to the concrete implementation to
-            handle.
-            """
-
-        @abstractmethod
         def set_version_range(self, lower_bound=None: Optional[TLSVersion],
                               upper_bound=None: Optional[TLSVersion]) -> None:
             """
@@ -361,6 +335,32 @@ The ``Context`` abstract base class has the following class definition::
             create an in-memory stream for TLS. The SSL routines will read data
             from ``incoming`` and decrypt it, and write encrypted data to
             ``outgoing``.
+            """
+
+        @abstractmethod
+        def set_sni_callback(self, callback: Optional[ServerNameCallback]) -> None:
+            """
+            Register a callback function that will be called after the TLS
+            Client Hello handshake message has been received by the TLS server
+            when the TLS client specifies a server name indication.
+
+            Only one callback can be set per ``Context``. If ``callback`` is
+            ``None`` then the callback is disabled. Calling this function a
+            subsequent time will disable the previously registered callback.
+
+            The ``callback`` function will be called with three arguments: the
+            first will be the ``TLSBufferObject`` for the connection; the
+            second will be a string that represents the server name that the
+            client is intending to communicate (or ``None`` if the TLS Client
+            Hello does not contain a server name); and the third argument will
+            be the original ``Context``. The server name argument will be the
+            IDNA *decoded* server name.
+
+            The ``callback`` must return ``None`` to allow negotiation to
+            continue. Other return values signal errors. Attempting to control
+            what error is signaled by the underlying TLS implementation is not
+            specified in this API, but is up to the concrete implementation to
+            handle.
             """
 
 

--- a/pep-0xxx.rst
+++ b/pep-0xxx.rst
@@ -171,6 +171,28 @@ The ``Context`` abstract base class has the following class definition::
     ServerNameCallback = Callable[[TLSBufferObject, Optional[str], Context], Any]
 
     class _BaseContext(metaclass=ABCMeta):
+
+        @property
+        @abstractmethod
+        def validate_certificates(self) -> bool:
+            """
+            Whether to validate the TLS certificates. This switch operates at a
+            very broad scope: either validation is enabled, in which case all
+            forms of validation are performed including hostname validation if
+            possible, or validation is disabled, in which case no validation is
+            performed.
+
+            Not all backends support having their certificate validation
+            disabled. If a backend does not support having their certificate
+            validation disabled, attempting to set this property to ``False``
+            will throw a ``TLSError``.
+            """
+
+        @validate_certificates.setter
+        @abstractmethod
+        def validate_certificates(self, val: bool) -> None:
+          pass
+
         @abstractmethod
         def register_certificates(self,
                                   certificates: str,
@@ -668,7 +690,6 @@ ToDo
   define one as part of this PEP? Otherwise, how do I define the types of the
   arguments to ``wrap_buffers``?
 * Do we need ways to control hostname validation?
-* Do we need ways to disable certificate validation altogether?
 * Do we need to support getpeercert? Should we always return DER instead of the
   weird semi-structured thing?
 * How do we load certs from locations on disk? What about HSMs?

--- a/pep-0xxx.rst
+++ b/pep-0xxx.rst
@@ -257,7 +257,7 @@ The ``Context`` abstract base class has the following class definition::
             """
             pass
 
-        @abstracmethod
+        @abstractmethod
         def set_version_range(self, lower_bound=None: Optional[TLSVersion],
                               upper_bound=None: Optional[TLSVersion]) -> None:
             """

--- a/pep-0xxx.rst
+++ b/pep-0xxx.rst
@@ -207,8 +207,8 @@ applied to specific TLSWrappedBuffer, and TLSWrappedSocket objects.
 For this reason, we split the responsibility of `SSLContext`_ into two separate
 objects. The ``TLSConfiguration`` object is an object that acts as container
 for TLS configuration: the ``ClientContext`` and ``ServerContext`` objects are
-objects that are instantiated with a ``TLSConfiguration`` object. Both objects
-would be immutable.
+objects that are instantiated with a ``TLSConfiguration`` object. All three
+objects would be immutable.
 
 Configuration
 ~~~~~~~~~~~~~

--- a/pep-0xxx.rst
+++ b/pep-0xxx.rst
@@ -698,7 +698,7 @@ as well.
 
     class Certificate(metaclass=ABCMeta):
         @abstractclassmethod
-        def from_buffer(self, buffer: bytes) -> Certificate:
+        def from_buffer(cls, buffer: bytes) -> Certificate:
             """
             Creates a Certificate object from a byte buffer. This byte buffer
             may be either PEM-encoded or DER-encoded. If the buffer is PEM
@@ -710,7 +710,7 @@ as well.
             """
 
         @abstractclassmethod
-        def from_file(self, path: Union[pathlib.Path, AnyStr]) -> Certificate:
+        def from_file(cls, path: Union[pathlib.Path, AnyStr]) -> Certificate:
             """
             Creates a Certificate object from a file on disk. This method may
             be a convenience method that wraps ``open`` and ``from_buffer``,
@@ -731,7 +731,7 @@ This class has all the caveats of the ``Certificate`` class.
 
     class PrivateKey(metaclass=ABCMeta):
         @abstractclassmethod
-        def from_buffer(self,
+        def from_buffer(cls,
                         buffer: bytes,
                         password=None: Optional[Union[Callable[[], Union[bytes, bytearray]], bytes, bytearray]) -> PrivateKey:
             """
@@ -755,7 +755,7 @@ This class has all the caveats of the ``Certificate`` class.
             """
 
         @abstractclassmethod
-        def from_file(self,
+        def from_file(cls,
                       path: Union[pathlib.Path, bytes, str],
                       password=None: Optional[Union[Callable[[], Union[bytes, bytearray]], bytes, bytearray]) -> PrivateKey:
             """

--- a/pep-0xxx.rst
+++ b/pep-0xxx.rst
@@ -852,6 +852,32 @@ any suitable API must allow the Python code to determine which ``ALG_ID``
 constants must be provided.
 
 
+Network Security Services (NSS)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+NSS is Mozilla's crypto and TLS library. It's used in Firefox, Thunderbird,
+and as alternative to OpenSSL in multiple libraries, e.g. curl.
+
+By default, NSS comes with secure configuration of allowed ciphers. On some
+platforms such as Fedora, the list of enabled ciphers is globally configured
+in a system policy. Generally, applications should not modify cipher suites
+unless they have specific reasons to do so.
+
+NSS has both process global and per-connection settings for cipher suites. It
+does not have a concept of SSLContext like OpenSSL. A SSLContext-like behavior
+can be easily emulated. Specifically, ciphers can be enabled or disabled
+globally with ```SSL_CipherPrefSetDefault(PRInt32 cipher, PRBool enabled)```,
+and ```SSL_CipherPrefSet(PRFileDesc *fd, PRInt32 cipher, PRBool enabled)```
+for a connection. The cipher ```PRInt32``` number is a signed 32bit integer
+that directly corresponds to an registered IANA id, e.g. ```0x1301```
+is ```TLS_AES_128_GCM_SHA256```. Contrary to OpenSSL, the preference order
+of ciphers is fixed and cannot be modified at runtime.
+
+Like SecureTransport, NSS has no API for aggregated entries. Some consumers
+of NSS have implemented custom mappings from OpenSSL cipher names and rules
+to NSS ciphers, e.g. ```mod_nss```.
+
+
 Proposed Interface
 ^^^^^^^^^^^^^^^^^^
 

--- a/pep-0xxx.rst
+++ b/pep-0xxx.rst
@@ -682,7 +682,7 @@ This class has all the caveats of the ``Certificate`` class.
         @abstractclassmethod
         def from_buffer(self,
                         buffer: bytes,
-                        password=None: Optional[Union[Callable[[], Union[AnyStr, bytearray]], AnyStr, bytearray]) -> Certificate:
+                        password=None: Optional[Union[Callable[[], Union[AnyStr, bytearray]], AnyStr, bytearray]) -> PrivateKey:
             """
             Creates a PrivateKey object from a byte buffer. This byte buffer
             may be either PEM-encoded or DER-encoded. If the buffer is PEM
@@ -708,7 +708,7 @@ This class has all the caveats of the ``Certificate`` class.
         @abstractclassmethod
         def from_file(self,
                       path: Union[pathlib.Path, bytes, str],
-                      password=None: Optional[Union[Callable[[], Union[AnyStr, bytearray]], AnyStr, bytearray]) -> Certificate:
+                      password=None: Optional[Union[Callable[[], Union[AnyStr, bytearray]], AnyStr, bytearray]) -> PrivateKey:
             """
             Creates a PrivateKey object from a file on disk. This method may
             be a convenience method that wraps ``open`` and ``from_buffer``,

--- a/pep-0xxx.rst
+++ b/pep-0xxx.rst
@@ -324,8 +324,9 @@ The ``TLSConfiguration`` object would be defined by the following code::
             second will be a string that represents the server name that the
             client is intending to communicate (or ``None`` if the TLS Client
             Hello does not contain a server name); and the third argument will
-            be the original ``Context``. The server name argument will be the
-            IDNA *decoded* server name.
+            be the original ``TLSConfiguration`` that configured the
+            connection. The server name argument will be the IDNA *decoded*
+            server name.
 
             The ``callback`` must return a ``TLSConfiguration`` to allow
             negotiation to continue. Other return values signal errors.

--- a/pep-0xxx.rst
+++ b/pep-0xxx.rst
@@ -919,14 +919,14 @@ implementation.
 ::
 
     class TLSVersion(Enum):
-        MINIMUM_SUPPORTED
-        SSLv2
-        SSLv3
-        TLSv1
-        TLSv1_1
-        TLSv1_2
-        TLSv1_3
-        MAXIMUM_SUPPORTED
+        MINIMUM_SUPPORTED = auto
+        SSLv2 = auto
+        SSLv3 = auto
+        TLSv1 = auto
+        TLSv1_1 = auto
+        TLSv1_2 = auto
+        TLSv1_3 = auto
+        MAXIMUM_SUPPORTED = auto
 
 
 Errors

--- a/pep-0xxx.rst
+++ b/pep-0xxx.rst
@@ -701,7 +701,7 @@ This class has all the caveats of the ``Certificate`` class.
         @abstractclassmethod
         def from_buffer(self,
                         buffer: bytes,
-                        password=None: Optional[Union[Callable[[], Union[AnyStr, bytearray]], AnyStr, bytearray]) -> PrivateKey:
+                        password=None: Optional[Union[Callable[[], Union[bytes, bytearray]], bytes, bytearray]) -> PrivateKey:
             """
             Creates a PrivateKey object from a byte buffer. This byte buffer
             may be either PEM-encoded or DER-encoded. If the buffer is PEM
@@ -716,18 +716,16 @@ This class has all the caveats of the ``Certificate`` class.
             may be a function to call to get the password for decrypting the
             private key. It will only be called if the private key is encrypted
             and a password is necessary. It will be called with no arguments,
-            and it should return a string, bytes, or bytearray. If the return
-            value is a string it will be encoded as UTF-8 before using it to
-            decrypt the key. Alternatively a string, bytes, or bytearray value
-            may be supplied directly as the password argument. It will be
-            ignored if the private key is not encrypted and no password is
-            needed.
+            and it should return either bytes or bytearray containing the
+            password. Alternatively a bytes, or bytearray value may be supplied
+            directly as the password argument. It will be ignored if the
+            private key is not encrypted and no password is needed.
             """
 
         @abstractclassmethod
         def from_file(self,
                       path: Union[pathlib.Path, bytes, str],
-                      password=None: Optional[Union[Callable[[], Union[AnyStr, bytearray]], AnyStr, bytearray]) -> PrivateKey:
+                      password=None: Optional[Union[Callable[[], Union[bytes, bytearray]], bytes, bytearray]) -> PrivateKey:
             """
             Creates a PrivateKey object from a file on disk. This method may
             be a convenience method that wraps ``open`` and ``from_buffer``,

--- a/pep-0xxx.rst
+++ b/pep-0xxx.rst
@@ -1031,7 +1031,7 @@ This class has all the caveats of the ``Certificate`` class.
         @abstractclassmethod
         def from_buffer(cls,
                         buffer: bytes,
-                        password=None: Optional[Union[Callable[[], Union[bytes, bytearray]], bytes, bytearray]) -> PrivateKey:
+                        password=None: Optional[Union[Callable[[], Union[bytes, bytearray]], bytes, bytearray]]) -> PrivateKey:
             """
             Creates a PrivateKey object from a byte buffer. This byte buffer
             may be either PEM-encoded or DER-encoded. If the buffer is PEM
@@ -1055,7 +1055,7 @@ This class has all the caveats of the ``Certificate`` class.
         @abstractclassmethod
         def from_file(cls,
                       path: Union[pathlib.Path, bytes, str],
-                      password=None: Optional[Union[Callable[[], Union[bytes, bytearray]], bytes, bytearray]) -> PrivateKey:
+                      password=None: Optional[Union[Callable[[], Union[bytes, bytearray]], bytes, bytearray]]) -> PrivateKey:
             """
             Creates a PrivateKey object from a file on disk. This method may
             be a convenience method that wraps ``open`` and ``from_buffer``,

--- a/pep-0xxx.rst
+++ b/pep-0xxx.rst
@@ -487,7 +487,9 @@ The ``Context`` abstract base class has the following class definition::
             host multiple SSL-based services with distinct certificates, quite
             similarly to HTTP virtual hosts. This is also used to validate the
             TLS certificate for the given hostname. If hostname validation is
-            not desired, then pass ``None`` for this parameter.
+            not desired, then pass ``None`` for this parameter. This parameter
+            has no default value because opting-out of hostname validation is
+            dangerous, and should not be the default behaviour.
 
             The parameter ``auto_handshake`` specifies whether to do the SSL
             handshake automatically after doing a ``socket.connect()``, or

--- a/pep-0xxx.rst
+++ b/pep-0xxx.rst
@@ -240,75 +240,70 @@ The ``TLSConfiguration`` object would be defined by the following code:
     ServerNameCallback = Callable[[TLSBufferObject, Optional[str], Context], Any]
 
 
-    class TLSConfiguration:
-        @property
-        def validate_certificates(self) -> bool:
-            """
-            Whether to validate the TLS certificates. This switch operates at a
-            very broad scope: either validation is enabled, in which case all
-            forms of validation are performed including hostname validation if
-            possible, or validation is disabled, in which case no validation is
-            performed.
+    _configuration_fields = [
+        'validate_certificates',
+        'certificate_chain',
+        'ciphers',
+        'inner_protocols',
+        'lowest_supported_version',
+        'highest_supported_version',
+        'trust_store',
+        'sni_callback',
+    ]
+
+
+    _DEFAULT_VALUE = object()
+
+
+    class TLSConfiguration(namedtuple('TLSConfiguration', _configuration_fields)):
+        """
+        An imutable TLS Configuration object. This object has the following
+        properties:
+
+        :param validate_certificates bool: Whether to validate the TLS
+            certificates. This switch operates at a very broad scope: either
+            validation is enabled, in which case all forms of validation are
+            performed including hostname validation if possible, or validation
+            is disabled, in which case no validation is performed.
 
             Not all backends support having their certificate validation
             disabled. If a backend does not support having their certificate
             validation disabled, attempting to set this property to ``False``
             will throw a ``TLSError`` when this object is passed into a
             context object.
-            """
 
-        @property
-        def certificate_chain(self) -> Tuple[List[Certificate], PrivateKey]:
-            """
-            The certificate, intermediate certificate, and the corresponding
+        :param certificate_chain Tuple[List[Certificate],PrivateKey]: The
+            certificate, intermediate certificate, and the corresponding
             private key for the leaf certificate. These certificates will be
             offered to the remote peer during the handshake if required.
 
             The first Certificate in the list must be the leaf certificate. All
             subsequent certificates will be offered as intermediate additional
             certificates.
-            """
 
-        @property
-        def ciphers(self) -> List[CipherSuite]:
-            """
+        :param ciphers List[CipherSuite]:
             The available ciphers for TLS connections created with this
             configuration, in priority order.
-            """
 
-        @property
-        def inner_protocols(self) -> List[Union[NextProtocol, bytes]]:
-            """
+        :param inner_protocols List[Union[NextProtocol, bytes]]:
             Protocols that connections created with this configuration should
             advertise as supported during the TLS handshake. These may be
             advertised using either or both of ALPN or NPN. This list of
             protocols should be ordered by preference.
-            """
 
-        @property
-        def lowest_supported_version(self) -> TLSVersion:
-            """
+        :param lowest_supported_version TLSVersion:
             The minimum version of TLS that should be allowed on TLS
             connections using this configuration.
-            """
 
-        @property
-        def highest_supported_version(self) -> TLSVersion:
-            """
+        :param highest_supported_version TLSVersion:
             The maximum version of TLS that should be allowed on TLS
             connections using this configuration.
-            """
 
-        @property
-        def trust_store(self) -> TrustStore:
-            """
+        :param trust_store TrustStore:
             The trust store that connections using this configuration will use
             to validate certificates.
-            """
 
-        @property
-        def sni_callback(self) -> Optional[ServerNameCallback]:
-            """
+        :param sni_callback Optional[ServerNameCallback]:
             A callback function that will be called after the TLS Client Hello
             handshake message has been received by the TLS server when the TLS
             client specifies a server name indication.
@@ -331,7 +326,82 @@ The ``TLSConfiguration`` object would be defined by the following code:
             what error is signaled by the underlying TLS implementation is not
             specified in this API, but is up to the concrete implementation to
             handle.
+        """
+        __slots__ = ()
+
+        def __new__(cls, validate_certificates=None: Optional[bool],
+                         certificate_chain=None: Optional[Tuple[List[Certificate], PrivateKey]],
+                         ciphers=None: Optional[List[CipherSuite]],
+                         inner_protocols=None: Optional[List[Union[NextProtocol, bytes]]],
+                         lowest_supported_version=None: Optional[TLSVersion],
+                         highest_supported_version=None: Optional[TLSVersion],
+                         trust_store=None: Optional[TrustStore],
+                         sni_callback=None: Optional[ServerNameCallback]):
+
+            if validate_certificates is None:
+                validate_certificates = True
+
+            if ciphers is None:
+                ciphers = DEFAULT_CIPHER_LIST
+
+            if inner_protocols is None:
+                inner_protocols = []
+
+            if lowest_supported_version is None:
+                lowest_supported_version = TLSVersion.TLSv1
+
+            if highest_supported_version is None:
+                highest_supported_version = TLSVersion.MAXIMUM_SUPPORTED
+
+            return super().__new__(
+                cls, validate_certificates, certificate_chain, ciphers,
+                inner_protocols, lowest_supported_version,
+                highest_supported_version, trust_store, sni_callback
+            )
+
+        def update(self, validate_certificates=_DEFAULT_VALUE,
+                         certificate_chain=_DEFAULT_VALUE,
+                         ciphers=_DEFAULT_VALUE,
+                         inner_protocols=_DEFAULT_VALUE,
+                         lowest_supported_version=_DEFAULT_VALUE,
+                         highest_supported_version=_DEFAULT_VALUE,
+                         trust_store=_DEFAULT_VALUE,
+                         sni_callback=_DEFAULT_VALUE):
             """
+            Create a new ``TLSConfiguration``, overriding some of the settings
+            on the original configuration with the new settings.
+            """
+            if validate_certificates is _DEFAULT_VALUE:
+                validate_certificates = self.validate_certificates
+
+            if certificate_chain is _DEFAULT_VALUE:
+                certificate_chain = self.certificate_chain
+
+            if ciphers is _DEFAULT_VALUE:
+                ciphers = self.ciphers
+
+            if inner_protocols is _DEFAULT_VALUE:
+                inner_protocols = self.inner_protocols
+
+            if lowest_supported_version is _DEFAULT_VALUE:
+                lowest_supported_version = self.lowest_supported_version
+
+            if highest_supported_version is _DEFAULT_VALUE:
+                highest_supported_version = self.highest_supported_version
+
+            if trust_store is _DEFAULT_VALUE:
+                trust_store = self.trust_store
+
+            if sni_callback is _DEFAULT_VALUE:
+                sni_callback = self.sni_callback
+
+            return self.__class__(
+                validate_certificates, certificate_chain, ciphers,
+                inner_protocols, lowest_supported_version,
+                highest_supported_version, trust_store, sni_callback
+            )
+
+
 
 Context
 ~~~~~~~

--- a/pep-0xxx.rst
+++ b/pep-0xxx.rst
@@ -1158,11 +1158,12 @@ This includes the following modules:
 
 - asyncio
 - ftplib
-- http.client
+- http
 - imaplib
 - nntplib
 - poplib
 - smtplib
+- urllib
 
 
 Migration of the ssl module

--- a/pep-0xxx.rst
+++ b/pep-0xxx.rst
@@ -241,7 +241,7 @@ configuration fields to this object as they become useful. For
 backwards-compatibility purposes, new fields are only appended to this object.
 Existing fields will never be removed, renamed, or reordered.
 
-The ``TLSConfiguration`` object would be defined by the following code:
+The ``TLSConfiguration`` object would be defined by the following code::
 
     ServerNameCallback = Callable[[TLSBufferObject, Optional[str], TLSConfiguration], Any]
 
@@ -743,7 +743,7 @@ biggest problem with this format is that there is no formal specification for
 it, meaning that the only way to parse a given string the way OpenSSL would is
 to get OpenSSL to parse it.
 
-OpenSSL's cipher strings can look like this:
+OpenSSL's cipher strings can look like this::
 
     'ECDH+AESGCM:ECDH+CHACHA20:DH+AESGCM:DH+CHACHA20:ECDH+AES256:DH+AES256:ECDH+AES128:DH+AES:RSA+AESGCM:RSA+AES:!aNULL:!eNULL:!MD5'
 
@@ -751,7 +751,7 @@ This string demonstrates some of the complexity of the OpenSSL format. For
 example, it is possible for one entry to specify multiple cipher suites: the
 entry ``ECDH+AESGCM`` means "all ciphers suites that include both
 elliptic-curve Diffie-Hellman key exchange and AES in Galois Counter Mode".
-More explicitly, that will expand to four cipher suites:
+More explicitly, that will expand to four cipher suites::
 
     "ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256"
 
@@ -771,7 +771,7 @@ OpenSSL also uses different names for its ciphers than the names used in the
 relevant specifications. See the manual page for ``ciphers(1)`` for more
 details.
 
-The actual API inside OpenSSL for the cipher string is simple:
+The actual API inside OpenSSL for the cipher string is simple::
 
     char *cipher_list = <some cipher list>;
     int rc = SSL_CTX_set_cipher_list(context, cipher_list);
@@ -797,7 +797,7 @@ names of the cipher suites: that is, the cipher suite that OpenSSL calls
 "ECDHE-ECDSA-AES256-GCM-SHA384" is called
 "TLS_ECDHE_ECDHSA_WITH_AES_256_GCM_SHA384" in SecureTransport.
 
-The API for configuring cipher suites inside SecureTransport is simple:
+The API for configuring cipher suites inside SecureTransport is simple::
 
     SSLCipherSuite ciphers[] = {TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384, ...};
     OSStatus status = SSLSetEnabledCiphers(context, ciphers, sizeof(cphers));
@@ -858,6 +858,8 @@ provide helpers that can reintroduce OpenSSL's aggregation functionality.
 Because this enum would be enormous, the entire enum is not provided here.
 Instead, a small sample of entries is provided to give a flavor of how it will
 appear.
+
+::
 
     class CipherSuite(Enum):
         ...
@@ -988,6 +990,8 @@ Concrete implementations should aim to have Certificate objects be hashable if
 at all possible. This will help ensure that TLSConfiguration objects used with
 an individual concrete implementation are also hashable.
 
+::
+
     class Certificate(metaclass=ABCMeta):
         @abstractclassmethod
         def from_buffer(cls, buffer: bytes) -> Certificate:
@@ -1020,6 +1024,8 @@ Certificate class, this class has almost no behaviour in order to give as much
 freedom as possible to the concrete implementations to treat keys carefully.
 
 This class has all the caveats of the ``Certificate`` class.
+
+::
 
     class PrivateKey(metaclass=ABCMeta):
         @abstractclassmethod
@@ -1085,6 +1091,8 @@ Concrete implementations should aim to have TrustStore objects be hashable if
 at all possible. This will help ensure that TLSConfiguration objects used with
 an individual concrete implementation are also hashable.
 
+::
+
     class TrustStore(metaclass=ABCMeta):
         @abstractclassmethod
         def system(cls) -> TrustStore:
@@ -1127,7 +1135,7 @@ All concrete implementations must provide a method of obtaining a ``Backend``
 object. The ``Backend`` object can be a global singleton or can be created by a
 callable if there is an advantage in doing that.
 
-The ``Backend`` object has the following definition:
+The ``Backend`` object has the following definition::
 
     Backend = namedtuple(
         'Backend',
@@ -1136,7 +1144,7 @@ The ``Backend`` object has the following definition:
     )
 
 Each of the properties must provide the concrete implementation of the relevant
-ABC. This ensures that code like this will work for any backend:
+ABC. This ensures that code like this will work for any backend::
 
     trust_store = backend.trust_store.system()
 

--- a/pep-0xxx.rst
+++ b/pep-0xxx.rst
@@ -420,6 +420,14 @@ has the following definition::
             The version of TLS that has been negotiated on this connection.
             """
 
+        @abstractmethod
+        def unwrap(self) -> socket.socket:
+            """
+            Cleanly terminate the TLS connection on this wrapped socket. Once
+            called, this ``TLSWrappedSocket`` can no longer be used to transmit
+            data. Returns the socket that was wrapped with TLS.
+            """
+
 
 Buffer
 ~~~~~~
@@ -506,6 +514,14 @@ has the following definition::
         def negotiated_tls_version(self) -> Optional[TLSVersion]:
             """
             The version of TLS that has been negotiated on this connection.
+            """
+
+        @abstractmethod
+        def shutdown(self) -> None:
+            """
+            Performs a clean TLS shut down. This should generally be used
+            whenever possible to signal to the remote peer that the content is
+            finished.
             """
 
 

--- a/pep-0xxx.rst
+++ b/pep-0xxx.rst
@@ -167,7 +167,7 @@ The ``Context`` abstract base class has the following class definition::
     TLSBufferObject = Union[TLSWrappedSocket, TLSWrappedBuffer]
     ServerNameCallback = Callable[[TLSBufferObject, Optional[str], Context], Any]
 
-    class Context(metaclass=ABCMeta):
+    class _BaseContext(metaclass=ABCMeta):
         @abstractmethod
         def register_certificates(self,
                                   certificates: str,
@@ -298,6 +298,82 @@ The ``Context`` abstract base class has the following class definition::
 
             The ``server_side`` and ``server_hostname`` parameters have the
             same meaning as in ``wrap_socket``.
+            """
+            pass
+
+
+    class ClientContext(metaclass=ABCMeta):
+        @abstractmethod
+        def wrap_socket(self, socket: socket.socket,
+                        auto_handshake=True: bool,
+                        server_hostname=None: Optional[str]) -> TLSWrappedSocket:
+            """
+            Wrap an existing Python socket object ``socket`` and return a
+            ``TLSWrappedSocket`` object. ``socket`` must be a ``SOCK_STREAM``
+            socket: all other socket types are unsupported.
+
+            The returned SSL socket is tied to the context, its settings and
+            certificates.
+
+            The parameter ``auto_handshake`` specifies whether to do the SSL
+            handshake automatically after doing a ``socket.connect()``, or
+            whether the application program will call it explicitly, by
+            invoking the ``TLSWrappedSocket.do_handshake()`` method. Calling
+            ``TLSWrappedSocket.do_handshake()`` explicitly gives the program
+            control over the blocking behavior of the socket I/O involved in
+            the handshake.
+
+            The optional parameter ``server_hostname`` specifies the hostname
+            of the service which we are connecting to. This allows a single
+            server to host multiple SSL-based services with distinct
+            certificates, quite similarly to HTTP virtual hosts.
+            """
+            pass
+
+        @abstractmethod
+        def wrap_buffers(self, incoming: Any, outgoing: Any,
+                         server_hostname=None: Optional[str]) -> TLSWrappedBuffer:
+            """
+            Wrap a pair of buffer objects (``incoming`` and ``outgoing``) to
+            create an in-memory stream for TLS. The SSL routines will read data
+            from ``incoming`` and decrypt it, and write encrypted data to
+            ``outgoing``.
+
+            The ``server_hostname`` parameter has the same meaning as in
+            ``wrap_socket``.
+            """
+            pass
+
+
+    class ServerContext(metaclass=ABCMeta):
+        @abstractmethod
+        def wrap_socket(self, socket: socket.socket,
+                        auto_handshake=True: bool) -> TLSWrappedSocket:
+            """
+            Wrap an existing Python socket object ``socket`` and return a
+            ``TLSWrappedSocket`` object. ``socket`` must be a ``SOCK_STREAM``
+            socket: all other socket types are unsupported.
+
+            The returned SSL socket is tied to the context, its settings and
+            certificates.
+
+            The parameter ``auto_handshake`` specifies whether to do the SSL
+            handshake automatically after doing a ``socket.connect()``, or
+            whether the application program will call it explicitly, by
+            invoking the ``TLSWrappedSocket.do_handshake()`` method. Calling
+            ``TLSWrappedSocket.do_handshake()`` explicitly gives the program
+            control over the blocking behavior of the socket I/O involved in
+            the handshake.
+            """
+            pass
+
+        @abstractmethod
+        def wrap_buffers(self, incoming: Any, outgoing: Any) -> TLSWrappedBuffer:
+            """
+            Wrap a pair of buffer objects (``incoming`` and ``outgoing``) to
+            create an in-memory stream for TLS. The SSL routines will read data
+            from ``incoming`` and decrypt it, and write encrypted data to
+            ``outgoing``.
             """
             pass
 

--- a/pep-0xxx.rst
+++ b/pep-0xxx.rst
@@ -1165,6 +1165,42 @@ This includes the following modules:
 - smtplib
 
 
+Migration of the ssl module
+---------------------------
+
+Naturally, we will need to extend the ``ssl`` module itself to conform to these
+ABCs. This extension will take the form of new classes, potentially in an
+entirely new module. This will allow applications that take advantage of the
+current ``ssl`` module to continue to do so, while enabling the new APIs for
+applications and libraries that want to use them.
+
+In general, migrating from the ``ssl`` module to the new ABCs is not expected
+to be one-to-one. This is normally acceptable: most tools that use the ``ssl``
+module hide it from the user, and so refactoring to use the new module should
+be invisible.
+
+However, a specific problem comes from libraries or applications that leak
+exceptions from the ``ssl`` module, either as part of their defined API or by
+accident (which is easily done). Users of those tools may have written code
+that tolerates and handles exceptions from the ``ssl`` module being raised:
+migrating to the ABCs presented here would potentially cause the exceptions
+defined above to be thrown instead, and existing ``except`` blocks will not
+catch them.
+
+For this reason, part of the migration of the ``ssl`` module would require that
+the exceptions in the ``ssl`` module alias those defined above. That is, they
+would require the following statements to all succeed::
+
+    assert ssl.SSLError is tls.TLSError
+    assert ssl.SSLWantReadError is tls.WantReadError
+    assert ssl.SSLWantWriteError is tls.WantWriteError
+
+The exact mechanics of how this will be done are beyond the scope of this PEP,
+as they are made more complex due to the fact that the current ``ssl``
+exceptions are defined in C code, but more details can be found in
+`an email sent to the Security-SIG by Christian Heimes`_.
+
+
 Future
 ======
 
@@ -1194,6 +1230,7 @@ References
 .. _SSLError: https://docs.python.org/3/library/ssl.html#ssl.SSLError
 .. _MSDN articles: https://msdn.microsoft.com/en-us/library/windows/desktop/mt490158(v=vs.85).aspx
 .. _tlsdb JSON file: https://github.com/tiran/tlsdb/blob/master/tlsdb.json
+.. _an email sent to the Security-SIG by Christian Heimes: https://mail.python.org/pipermail/security-sig/2017-January/000213.html
 
 
 Copyright

--- a/pep-0xxx.rst
+++ b/pep-0xxx.rst
@@ -1117,14 +1117,14 @@ implementation.
 ::
 
     class TLSVersion(Enum):
-        MINIMUM_SUPPORTED = auto
-        SSLv2 = auto
-        SSLv3 = auto
-        TLSv1 = auto
-        TLSv1_1 = auto
-        TLSv1_2 = auto
-        TLSv1_3 = auto
-        MAXIMUM_SUPPORTED = auto
+        MINIMUM_SUPPORTED = auto()
+        SSLv2 = auto()
+        SSLv3 = auto()
+        TLSv1 = auto()
+        TLSv1_1 = auto()
+        TLSv1_2 = auto()
+        TLSv1_3 = auto()
+        MAXIMUM_SUPPORTED = auto()
 
 
 Errors

--- a/pep-0xxx.rst
+++ b/pep-0xxx.rst
@@ -1,15 +1,15 @@
 PEP: XXX
-Title: TLS Abstract Base Classes
+Title: A Unified TLS API for Python
 Version: $Revision$
 Last-Modified: $Date$
-Author: Cory Benfield <cory@lukasa.co.uk>
-    Christian Heimes <christian@python.org>
+Author: Cory Benfield <cory@lukasa.co.uk>,
+        Christian Heimes <christian@python.org>
 Status: Draft
 Type: Standards Track
 Content-Type: text/x-rst
 Created: 17-Oct-2016
 Python-Version: 3.7
-Post-History: 30-Aug-2002
+Post-History: 11-Jan-2017, 19-Jan-2017, 02-Feb-2017, 09-Feb-2017
 
 
 Abstract

--- a/pep-0xxx.rst
+++ b/pep-0xxx.rst
@@ -1122,8 +1122,16 @@ enum member ``TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384`` as having the value
 enum. This makes mapping between SecureTransport and the above enum very easy
 indeed.
 
+For SChannel there is no easy direct mapping, due to the fact that SChannel
+configures ciphers, instead of cipher suites. This represents an ongoing
+concern with SChannel, which is that it is very difficult to configure in a
+specific manner compared to other TLS implementations.
 
-.. TODO: Figure out mappings for SChannel
+For the purposes of this PEP, any SChannel implementation will need to
+determine which ciphers to choose based on the enum members. This may be more
+open than the actual cipher suite list actually wants to allow, or it may be
+more restrictive, depending on the choices of the implementation. This PEP
+recommends that it be more restrictive, but of course this cannot be enforced.
 
 
 Protocol Negotiation

--- a/pep-0xxx.rst
+++ b/pep-0xxx.rst
@@ -292,7 +292,7 @@ The ``TLSConfiguration`` object would be defined by the following code::
             subsequent certificates will be offered as intermediate additional
             certificates.
 
-        :param ciphers Tuple[CipherSuite]:
+        :param ciphers Tuple[Union[CipherSuite, int]]:
             The available ciphers for TLS connections created with this
             configuration, in priority order.
 
@@ -349,7 +349,7 @@ The ``TLSConfiguration`` object would be defined by the following code::
 
         def __new__(cls, validate_certificates: Optional[bool] = None,
                          certificate_chain: Optional[Tuple[Tuple[Certificate], PrivateKey]] = None,
-                         ciphers: Optional[Tuple[CipherSuite]] = None,
+                         ciphers: Optional[Tuple[Union[CipherSuite, int]]] = None,
                          inner_protocols: Optional[Tuple[Union[NextProtocol, bytes]]] = None,
                          lowest_supported_version: Optional[TLSVersion] = None,
                          highest_supported_version: Optional[TLSVersion] = None,
@@ -571,11 +571,13 @@ has the following definition::
             """
 
         @abstractmethod
-        def cipher(self) -> Optional[CipherSuite]:
+        def cipher(self) -> Optional[Union[CipherSuite, int]]:
             """
             Returns the CipherSuite entry for the cipher that has been
             negotiated on the connection. If no connection has been negotiated,
-            returns ``None``.
+            returns ``None``. If the cipher negotiated is not defined in
+            CipherSuite, returns the 16-bit integer representing that cipher
+            directly.
             """
 
         @abstractmethod
@@ -704,11 +706,13 @@ has the following definition::
             """
 
         @abstractmethod
-        def cipher(self) -> Optional[CipherSuite]:
+        def cipher(self) -> Optional[Union[CipherSuite, int]]:
             """
             Returns the CipherSuite entry for the cipher that has been
             negotiated on the connection. If no connection has been negotiated,
-            returns ``None``.
+            returns ``None``. If the cipher negotiated is not defined in
+            CipherSuite, returns the 16-bit integer representing that cipher
+            directly.
             """
 
         @abstractmethod
@@ -921,6 +925,11 @@ does not contain ciphers with:
 five additional cipher suites from the TLS 1.3 draft (draft-ietf-tls-tls13-18)
 are included, too. TLS 1.3 does not share any cipher suites with TLS 1.2 and
 earlier. The resulting enum will contain roughly 110 suites.
+
+Because of these limitations, and because the enum doesn't contain every
+defined cipher, and also to allow for forward-looking applications, all parts
+of this API that accept ``CipherSuite`` objects will also accept raw 16-bit
+integers directly.
 
 Rather than populate this enum by hand, we have a `TLS enum script`_ that
 builds it from Christian Heimes' `tlsdb JSON file`_ (warning:

--- a/pep-0xxx.rst
+++ b/pep-0xxx.rst
@@ -551,9 +551,6 @@ The ``Context`` abstract base class has the following class definition::
             the individual TLS implementation. This allows TLS libraries that
             have their own specialised support to continue to do so, while
             allowing those without to use whatever Python objects they see fit.
-
-            The buffer objects must be either file objects or objects that
-            implement the buffer protocol.
             """
 
 

--- a/pep-0xxx.rst
+++ b/pep-0xxx.rst
@@ -1499,8 +1499,35 @@ configuration option for the Python community. TLS is not a static target, and
 as TLS evolves so must this API.
 
 
-References
-==========
+Credits
+=======
+
+This document has received extensive review from a number of individuals in the
+community who have substantially helped shape it. Review was provided by:
+
+* Alex Chan
+* Alex Gaynor
+* Antoine Pitrou
+* Ashwini Oruganti
+* Donald Stufft
+* Ethan Furman
+* Glyph
+* Hynek Schlawack
+* Jim J Jewett
+* Nathaniel J. Smith
+* Nick Coghlan
+* Paul Kehrer
+* Steve Dower
+* Steven Fackler
+* Wes Turner
+* Will Bond
+
+
+Copyright
+=========
+
+This document has been placed in the public domain.
+
 
 .. _ssl module: https://docs.python.org/3/library/ssl.html
 .. _OpenSSL Library: https://www.openssl.org/
@@ -1517,14 +1544,6 @@ References
 .. _an email sent to the Security-SIG by Christian Heimes: https://mail.python.org/pipermail/security-sig/2017-January/000213.html
 .. _s2n: https://github.com/awslabs/s2n
 .. _working to add it: https://github.com/awslabs/s2n/issues/358
-
-
-Copyright
-=========
-
-This document has been placed in the public domain.
-
-
 
 ..
    Local Variables:

--- a/pep-0xxx.rst
+++ b/pep-0xxx.rst
@@ -1059,7 +1059,15 @@ Enum members can be mapped to OpenSSL cipher names::
     'ECDHE-RSA-AES128-GCM-SHA256'
 
 
-.. TODO: Figure out mappings for SChannel and SecureTransport
+For SecureTransport, these enum members directly refer to the values of the
+cipher suite constants. For example, SecureTransport defines the cipher suite
+enum member ``TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384`` as having the value
+``0xC02C``. Not coincidentally, that is identical to its value in the above
+enum. This makes mapping between SecureTransport and the above enum very easy
+indeed.
+
+
+.. TODO: Figure out mappings for SChannel
 
 
 Protocol Negotiation

--- a/pep-0xxx.rst
+++ b/pep-0xxx.rst
@@ -624,13 +624,10 @@ has the following definition::
 
     class TLSWrappedBuffer(metaclass=ABCMeta):
         @abstractmethod
-        def read(self, amt: int = None) -> bytes:
+        def read(self, amt: int) -> bytes:
             """
             Read up to ``amt`` bytes of data from the input buffer and return
-            the result as a ``bytes`` instance. If ``amt`` is ``None``, will
-            attempt to read until either EOF is reached or until further
-            attempts to read would raise either ``WantReadError`` or
-            ``WantWriteError``.
+            the result as a ``bytes`` instance.
 
             Once EOF is reached, all further calls to this method return the
             empty byte string ``b''``.
@@ -651,14 +648,11 @@ has the following definition::
             """
 
         @abstractmethod
-        def readinto(self, buffer: Any, amt: int = None) -> int:
+        def readinto(self, buffer: Any, amt: int) -> int:
             """
             Read up to ``amt`` bytes of data from the input buffer into
             ``buffer``, which must be an object that implements the buffer
-            protocol. Returns the number of bytes read. If ``amt`` is ``None``,
-            will attempt to read until either EOF is reached or until further
-            attempts to read would raise either ``WantReadError`` or
-            ``WantWriteError``, or until the buffer is full.
+            protocol. Returns the number of bytes read.
 
             Once EOF is reached, all further calls to this method return the
             empty byte string ``b''``.

--- a/pep-0xxx.rst
+++ b/pep-0xxx.rst
@@ -635,6 +635,9 @@ has the following definition::
             Once EOF is reached, all further calls to this method return the
             empty byte string ``b''``.
 
+            May read "short": that is, fewer bytes may be returned than were
+            requested.
+
             Raise ``WantReadError`` or ``WantWriteError`` if there is
             insufficient data in either the input or output buffer and the
             operation would have caused data to be written or read.
@@ -664,6 +667,9 @@ has the following definition::
             insufficient data in either the input or output buffer and the
             operation would have caused data to be written or read.
 
+            May read "short": that is, fewer bytes may be read than were
+            requested.
+
             May raise ``RaggedEOF`` if the connection has been closed without a
             graceful TLS shutdown. Whether this is an exception that should be
             ignored or not is up to the specific application.
@@ -681,7 +687,14 @@ has the following definition::
 
             Raise ``WantReadError`` or ``WantWriteError`` if there is
             insufficient data in either the input or output buffer and the
-            operation would have caused data to be written or read.
+            operation would have caused data to be written or read. In either
+            case, users should endeavour to resolve that situation and then
+            re-call this method. When re-calling this method users *should*
+            re-use the exact same ``buf`` object, as some backends require that
+            the exact same buffer be used.
+
+            This operation may write "short": that is, fewer bytes may be
+            written than were in the buffer.
 
             As at any time a re-negotiation is possible, a call to ``write()``
             can also cause read operations.
@@ -1005,6 +1018,10 @@ The definitions of the errors are below::
         buffer-only I/O is used. This error signals that the requested
         operation cannot complete until more data is written to the network,
         or until the output buffer is drained.
+
+        This error is should only be raised when it is completely impossible
+        to write any data. If a partial write is achievable then this should
+        not be raised.
         """
 
     class WantReadError(TLSError):
@@ -1013,6 +1030,10 @@ The definitions of the errors are below::
         buffer-only I/O is used. This error signals that the requested
         operation cannot complete until more data is read from the network, or
         until more data is available in the input buffer.
+
+        This error should only be raised when it is completely impossible to
+        write any data. If a partial write is achievable then this should not
+        be raised.
         """
 
     class RaggedEOF(TLSError):

--- a/pep-0xxx.rst
+++ b/pep-0xxx.rst
@@ -1503,7 +1503,8 @@ Credits
 =======
 
 This document has received extensive review from a number of individuals in the
-community who have substantially helped shape it. Review was provided by:
+community who have substantially helped shape it. Detailed review was provided
+by:
 
 * Alex Chan
 * Alex Gaynor
@@ -1521,6 +1522,8 @@ community who have substantially helped shape it. Review was provided by:
 * Steven Fackler
 * Wes Turner
 * Will Bond
+
+Further review was provided by the Security-SIG and python-ideas mailing lists.
 
 
 Copyright

--- a/pep-0xxx.rst
+++ b/pep-0xxx.rst
@@ -3,6 +3,7 @@ Title: TLS Abstract Base Classes
 Version: $Revision$
 Last-Modified: $Date$
 Author: Cory Benfield <cory@lukasa.co.uk>
+    Christian Heimes <christian@python.org>
 Status: Draft
 Type: Standards Track
 Content-Type: text/x-rst

--- a/pep-0xxx.rst
+++ b/pep-0xxx.rst
@@ -487,7 +487,12 @@ The ``Context`` abstract base class has the following class definition::
             socket: all other socket types are unsupported.
 
             The returned SSL socket is tied to the context, its settings and
-            certificates.
+            certificates. The socket object originally passed to this method
+            should not be used again: attempting to use it in any way will lead
+            to undefined behaviour, especially across different TLS
+            implementations. To get the original socket object back once it has
+            been wrapped in TLS, see the ``unwrap`` method of the
+            TLSWrappedSocket.
 
             The parameter ``server_hostname`` specifies the hostname of the
             service which we are connecting to. This allows a single server to
@@ -525,7 +530,12 @@ The ``Context`` abstract base class has the following class definition::
             socket: all other socket types are unsupported.
 
             The returned SSL socket is tied to the context, its settings and
-            certificates.
+            certificates. The socket object originally passed to this method
+            should not be used again: attempting to use it in any way will lead
+            to undefined behaviour, especially across different TLS
+            implementations. To get the original socket object back once it has
+            been wrapped in TLS, see the ``unwrap`` method of the
+            TLSWrappedSocket.
             """
 
         @abstractmethod


### PR DESCRIPTION
This pull request tracks my work on the PEP for the TLS ABCs. This PEP is focused on defining a limited interface that can be implemented by any TLS backend for Python, allowing Python network implementations that don't have specific low-level requirements to obtain support for multiple TLS backends.

I've put this up as a GitHub pull request to allow anyone who is interested to provide feedback before I post this PEP to python-dev. My intended flow for this PEP is as follows:
1. Review by individuals (on this PR).
2. Submit to the Python Security SIG for review.
3. Submit to Python-Dev for review.
4. Merge
5. Implement (!)

Anyone who likes may leave inline comments on this diff. Shout if you'd like to be able to use GitHub's review feature and I can add you as a collab on this repository to make it a bit easier.
